### PR TITLE
Avoid reseting the context for every editor change

### DIFF
--- a/pemFioi/quickAlgo/python_interface.js
+++ b/pemFioi/quickAlgo/python_interface.js
@@ -386,7 +386,7 @@ function LogicController(nbTestCases, maxInstructions) {
       }
 
       // Interrupt any ongoing execution
-      if(that._mainContext.runner) {
+      if(that._mainContext.runner && that._mainContext.runner.isRunning()) {
          that._mainContext.runner.stop();
          that._mainContext.reset();
       }


### PR DESCRIPTION
This was causing a redrawing of the quickpi display for every character typed in the python editor.