### PR TITLE
Start i18n for python_interface

### DIFF
--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -111,7 +111,18 @@ var localLanguageStrings = {
       testError: "erreur",
       testSuccess: "validé",
       seeTest: "voir",
-      infiniteLoop: "répéter indéfiniment"
+      infiniteLoop: "répéter indéfiniment",
+      availableFunctions: "Fonctions disponibles : ",
+      availableFunctionsVerbose: "Les fonctions disponibles pour contrôler le robot sont :",
+      startingLine: "Votre programme doit commencer par la ligne",
+      startingLines: "Votre programme doit commencer par les lignes",
+      keywordAllowed: "Le mot-clé suivant est autorisé : ",
+      keywordForbidden: "Le mot-clé suivant est interdit : ",
+      keywordsAllowed: "Les mots-clés suivants sont autorisés : ",
+      keywordsForbidden: "Les mots-clés suivants sont interdits : ",
+      variablesAllowd: "Les variables sont autorisées.",
+      variablesForbidden: "Les variables sont interdites.",
+      readDocumentation: "Vous êtes autorisé(e) à lire de la documentation sur Python et à utiliser un moteur de recherche pendant le concours.",
    },
    en: {
       categories: {
@@ -217,7 +228,19 @@ var localLanguageStrings = {
       testLabel: "Test",
       testError: "error",
       testSuccess: "valid",
-      seeTest: "see test"
+      seeTest: "see test",
+      infiniteLoop: "répéter indéfiniment", // TODO :: translate
+      availableFunctions: "Fonctions disponibles : ", // TODO :: translate
+      availableFunctionsVerbose: "Les fonctions disponibles pour contrôler le robot sont :", // TODO :: translate
+      startingLine: "Votre programme doit commencer par la ligne", // TODO :: translate
+      startingLines: "Votre programme doit commencer par les lignes", // TODO :: translate
+      keywordAllowed: "Le mot-clé suivant est autorisé : ", // TODO :: translate
+      keywordForbidden: "Le mot-clé suivant est interdit : ", // TODO :: translate
+      keywordsAllowed: "Les mots-clés suivants sont autorisés : ", // TODO :: translate
+      keywordsForbidden: "Les mots-clés suivants sont interdits : ", // TODO :: translate
+      variablesAllowd: "Les variables sont autorisées.", // TODO :: translate
+      variablesForbidden: "Les variables sont interdites.", // TODO :: translate
+      readDocumentation: "Vous êtes autorisé(e) à lire de la documentation sur Python et à utiliser un moteur de recherche pendant le concours.", // TODO :: translate
    },
    de: {
       categories: {
@@ -324,7 +347,19 @@ var localLanguageStrings = {
       testLabel: "Test",
       testError: "Fehler",
       testSuccess: "gültig",
-      seeTest: "Siehe Test"
+      seeTest: "Siehe Test",
+      infiniteLoop: "Endlosschleife", 
+      availableFunctions: "Verfügbare Funktionen:",
+      availableFunctionsVerbose: "Die verfügbaren Funktionen zum Steuern des Roboters sind:",
+      startingLine: "Dein Programm muss mit folgender Zeile beginnen:",
+      startingLines: "Dein Programm muss mit folgenden Zeilen beginnen",
+      keywordAllowed: "Erlaubtes Schlüsselwort:",
+      keywordForbidden: "Nicht erlaubtes Schlüsselwort:",
+      keywordsAllowed: "Erlaubte Schlüsselwörter:",
+      keywordsForbidden: "Nicht erlaubte Schlüsselwörter:",
+      variablesAllowd: "Du darfst Variable verwenden.",
+      variablesForbidden: "Du darfst keine Variablen verwenden",
+      readDocumentation: "Du darfst die Python-Dokumentation lesen.",
    },
    es: {
       categories: {
@@ -430,7 +465,19 @@ var localLanguageStrings = {
       testLabel: "Caso",
       testError: "error",
       testSuccess: "correcto",
-      seeTest: "ver"
+      seeTest: "ver",
+      infiniteLoop: "répéter indéfiniment", // TODO :: translate
+      availableFunctions: "Fonctions disponibles : ", // TODO :: translate
+      availableFunctionsVerbose: "Les fonctions disponibles pour contrôler le robot sont :", // TODO :: translate
+      startingLine: "Votre programme doit commencer par la ligne", // TODO :: translate
+      startingLines: "Votre programme doit commencer par les lignes", // TODO :: translate
+      keywordAllowed: "Le mot-clé suivant est autorisé : ", // TODO :: translate
+      keywordForbidden: "Le mot-clé suivant est interdit : ", // TODO :: translate
+      keywordsAllowed: "Les mots-clés suivants sont autorisés : ", // TODO :: translate
+      keywordsForbidden: "Les mots-clés suivants sont interdits : ", // TODO :: translate
+      variablesAllowd: "Les variables sont autorisées.", // TODO :: translate
+      variablesForbidden: "Les variables sont interdites.", // TODO :: translate
+      readDocumentation: "Vous êtes autorisé(e) à lire de la documentation sur Python et à utiliser un moteur de recherche pendant le concours.", // TODO :: translate
    },
    sl: {
       categories: {
@@ -536,7 +583,19 @@ var localLanguageStrings = {
       testLabel: "Test",
       testError: "napaka",
       testSuccess: "pravilno",
-      seeTest: "poglej test"
+      seeTest: "poglej test",
+      infiniteLoop: "répéter indéfiniment", // TODO :: translate
+      availableFunctions: "Fonctions disponibles : ", // TODO :: translate
+      availableFunctionsVerbose: "Les fonctions disponibles pour contrôler le robot sont :", // TODO :: translate
+      startingLine: "Votre programme doit commencer par la ligne", // TODO :: translate
+      startingLines: "Votre programme doit commencer par les lignes", // TODO :: translate
+      keywordAllowed: "Le mot-clé suivant est autorisé : ", // TODO :: translate
+      keywordForbidden: "Le mot-clé suivant est interdit : ", // TODO :: translate
+      keywordsAllowed: "Les mots-clés suivants sont autorisés : ", // TODO :: translate
+      keywordsForbidden: "Les mots-clés suivants sont interdits : ", // TODO :: translate
+      variablesAllowd: "Les variables sont autorisées.", // TODO :: translate
+      variablesForbidden: "Les variables sont interdites.", // TODO :: translate
+      readDocumentation: "Vous êtes autorisé(e) à lire de la documentation sur Python et à utiliser un moteur de recherche pendant le concours.", // TODO :: translate
    }
 };
 

--- a/pemFioi/quickAlgo/python_interface.js
+++ b/pemFioi/quickAlgo/python_interface.js
@@ -590,8 +590,9 @@ function LogicController(nbTestCases, maxInstructions) {
 
     var availableModules = this.getAvailableModules();
     if(availableModules.length) {
-      fullHtml += '<p>Votre programme doit commencer par ';
-      fullHtml += (availableModules.length > 1) ? 'les lignes' : 'la ligne';
+      fullHtml += '<p>' + (availableModules.length > 1) ? 
+                  window.languageStrings.startingLine :
+                  window.languageStrings.startingLines;
       fullHtml += ' :</p>'
                  +  '<p><code>'
                  +  'from ' + availableModules[0] + ' import *';
@@ -599,9 +600,9 @@ function LogicController(nbTestCases, maxInstructions) {
         fullHtml += '\nfrom ' + availableModules[i] + ' import *';
       }
       fullHtml += '</code></p>'
-                 +  '<p>Les fonctions disponibles pour contrôler le robot sont :</p>'
+                 +  '<p>' + window.languageStrings.availableFunctionsVerbose + '</p>'
                  +  '<ul>';
-      simpleHtml += 'Fonctions disponibles : ';
+      simpleHtml += window.languageStrings.availableFunctions;
 
       var availableConsts = [];
 
@@ -704,12 +705,13 @@ function LogicController(nbTestCases, maxInstructions) {
         }
       }
 
-      var word = allowed ? 'autorisé' : 'interdit';
+      var word = allowed ? window.languageStrings.keywordAllowed : window.languageStrings.keywordForbidden;
+      var words = allowed ? window.languageStrings.keywordsAllowed : window.languageStrings.keywordsForbidden;
       var cls = allowed ? '' : ' class="pflForbidden"';
       if(list.length == 1) {
-        fullHtml += '<p>Le mot-clé suivant est ' + word + ' : <code'+cls+'>' + list[0] + '</code>.</p>';
+        fullHtml += '<p>' + word + ' <code'+cls+'>' + list[0] + '</code>.</p>';
       } else if(list.length > 0) {
-        fullHtml += '<p>Les mots-clés suivants sont ' + word + 's : <code'+cls+'>' + list.join('</code>, <code'+cls+'>') + '</code>.</p>';
+        fullHtml += '<p>' + words + ' <code'+cls+'>' + list.join('</code>, <code'+cls+'>') + '</code>.</p>';
       }
       return list;
     }
@@ -720,12 +722,12 @@ function LogicController(nbTestCases, maxInstructions) {
     }
 
     if(pflInfos.allowed.indexOf('var_assign') > -1) {
-      fullHtml += '<p>Les variables sont autorisées.</p>';
+      fullHtml += '<p>' + window.languageStrings.variablesAllowed + '</p>';
     } else {
-      fullHtml += '<p>Les variables sont interdites.</p>';
+      fullHtml += '<p>' + window.languageStrings.variablesForbidden + '</p>';
     }
 
-    fullHtml += '<p>Vous êtes autorisé(e) à lire de la documentation sur Python et à utiliser un moteur de recherche pendant le concours.</p>';
+    fullHtml += '<p>' + window.languageStrings.readDocumentation + '</p>';
 
     $('.pythonIntroSimple').html(simpleHtml);
     $('.pythonIntroFull').html(fullHtml);
@@ -798,11 +800,11 @@ function LogicController(nbTestCases, maxInstructions) {
     var that = this;
     var div = $('.pythonIntroBtn').html('');
     if(collapse) {
-      $('<a>Plus de détails</a>').appendTo(div).on('click', function() { that.collapseTaskIntro(false); });
+      $('<a>' + window.languageStrings.showDetails + '</a>').appendTo(div).on('click', function() { that.collapseTaskIntro(false); });
       $('.pythonIntro .pythonIntroFull').hide();
       $('.pythonIntro .pythonIntroSimple').show();
     } else {
-      $('<a>Moins de détails</a>').appendTo(div).on('click', function() { that.collapseTaskIntro(true); });
+      $('<a>' + window.languageStrings.hideDetails + '</a>').appendTo(div).on('click', function() { that.collapseTaskIntro(true); });
       $('.pythonIntro .pythonIntroFull').show();
       $('.pythonIntro .pythonIntroSimple').hide();
     }


### PR DESCRIPTION
In this PR I started to make some strings in `pemFioi/quickAlgo/python_interface.js` use `i18n.js` as source string so they can be translated into different languages.

Before continuing I'd like to check that my approach is the way it is supposed to be or whether there are some recommendations to enable translating in some other way.