### PR TITLE
QuickPi - Changed category 'Action' to 'Actuators' which is more relevant

### DIFF
--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -6,7 +6,8 @@
 var quickAlgoLanguageStrings = {
    fr: {
       categories: {
-         actions: "Actions",
+         actions: "Action",
+         actuator: "Actionneurs",
          sensors: "Capteurs",
          debug: "Débogage",
          colour: "Couleurs",
@@ -128,6 +129,7 @@ var quickAlgoLanguageStrings = {
    en: {
       categories: {
          actions: "Actions",
+         actuator: "Actuators",
          sensors: "Sensors",
          debug: "Debug",
          colour: "Colors",
@@ -247,6 +249,7 @@ var quickAlgoLanguageStrings = {
    de: {
       categories: {
          actions: "Aktionen",
+         actuator: "Actuators",
          sensors: "Sensoren",
          debug: "Debug",
          colour: "Farben",
@@ -367,6 +370,7 @@ var quickAlgoLanguageStrings = {
    es: {
       categories: {
          actions: "Acciones",
+         actuator: "Actuators",
          sensors: "Sensores",
          debug: "Depurar",
          colour: "Colores",
@@ -488,6 +492,7 @@ var quickAlgoLanguageStrings = {
    sl: {
       categories: {
          actions: "Dejanja",
+         actuator: "Actuators",
          sensors: "Senzorji",
          debug: "Razhroščevanje",
          colour: "Barve",
@@ -607,6 +612,7 @@ var quickAlgoLanguageStrings = {
    it: {
       categories: {
          actions: "Azioni",
+         actuator: "Actuators",
          sensors: "Sensori",
          debug: "Debug",
          colour: "Colori",

--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -6,7 +6,7 @@
 var quickAlgoLanguageStrings = {
    fr: {
       categories: {
-         actions: "Action",
+         actions: "Actions",
          actuator: "Actionneurs",
          sensors: "Capteurs",
          debug: "Débogage",

--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -249,7 +249,7 @@ var quickAlgoLanguageStrings = {
    de: {
       categories: {
          actions: "Aktionen",
-         actuator: "Actuators",
+         actuator: "Aktoren",
          sensors: "Sensoren",
          debug: "Debug",
          colour: "Farben",
@@ -370,7 +370,7 @@ var quickAlgoLanguageStrings = {
    es: {
       categories: {
          actions: "Acciones",
-         actuator: "Actuators",
+         actuator: "Actuadores",
          sensors: "Sensores",
          debug: "Depurar",
          colour: "Colores",
@@ -492,7 +492,7 @@ var quickAlgoLanguageStrings = {
    sl: {
       categories: {
          actions: "Dejanja",
-         actuator: "Actuators",
+         actuator: "Pogoni",
          sensors: "Senzorji",
          debug: "Razhroščevanje",
          colour: "Barve",
@@ -612,7 +612,7 @@ var quickAlgoLanguageStrings = {
    it: {
       categories: {
          actions: "Azioni",
-         actuator: "Actuators",
+         actuator: "Attuatori",
          sensors: "Sensori",
          debug: "Debug",
          colour: "Colori",

--- a/pemFioi/quickpi/blocklyQuickPiDistributed_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPiDistributed_lib.js
@@ -1360,7 +1360,7 @@ var getContext = function (display, infos, curLevel) {
       // Define our blocks for our namespace "distributed"
       distributed: {
          // Categories are reflected in the Blockly menu
-         actions: [
+         actuator: [
             { name: "getNodeID", yieldsValue: true },
             { name: "getNeighbors", yieldsValue: true },
             {
@@ -1390,7 +1390,7 @@ var getContext = function (display, infos, curLevel) {
    context.provideBlocklyColours = function () {
       return {
          categories: {
-            actions: 0,
+            actuator: 0,
             sensors: 100
          }
       };

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -9671,7 +9671,7 @@ var getContext = function (display, infos, curLevel) {
                 },
 
             ],
-            actions: [
+            actuator: [
                 { name: "turnLedOn" },
                 { name: "turnLedOff" },
                 { name: "turnBuzzerOn" },
@@ -10036,7 +10036,7 @@ var getContext = function (display, infos, curLevel) {
     context.provideBlocklyColours = function () {
         return {
             categories: {
-                actions: 0,
+                actuator: 0,
                 sensors: 100,
                 internet: 200,
                 display: 300,


### PR DESCRIPTION
The blockly category "action" has been renamed to "actuator", which is a more relevant name for these components.

I needed to add the "actuator" category for all languages, but since now, actuator only exist in QuickPi, so only QuickPi is normally impacted by these changes.

For the translations, the file and line to modify for translation is referenced inside of the Google Sheet.