### PR TITLE
[QuickPi][Documentation] Made documentation of basic concepts appear first (order 100-115)

### DIFF
--- a/pemFioi/conceptViewer-1.0-mobileFirst.js
+++ b/pemFioi/conceptViewer-1.0-mobileFirst.js
@@ -340,22 +340,22 @@ function getConceptViewerBaseConcepts() {
     // Get base concepts in the default help
     var baseUrl = getConceptViewerBaseUrl();
     var baseConcepts = [
-        {id: 'taskplatform', name: 'Résolution des exercices', url: baseUrl+'#taskplatform', language: 'all'},
-        {id: 'language', name: "Création d'un programme", url: baseUrl+'#language'},
-        {id: 'blockly_text_print', name: 'Afficher du texte', url: baseUrl+'#blockly_text_print'},
-        {id: 'blockly_text_print_noend', name: 'Afficher consécutivement du texte', url: baseUrl+'#blockly_text_print_noend'},
-        {id: 'blockly_controls_repeat', name: 'Boucles de répétition', url: baseUrl+'#blockly_controls_repeat'},
-        {id: 'blockly_controls_if', name: 'Conditions si', url: baseUrl+'#blockly_controls_if'},
-        {id: 'blockly_controls_if_else', name: 'Conditions si/sinon', url: baseUrl+'#blockly_controls_if_else'},
-        {id: 'blockly_controls_whileUntil', name: 'Boucles tant que ou jusqu\'à', url: baseUrl+'#blockly_controls_whileUntil'},
-        {id: 'blockly_controls_infiniteloop', name: 'Boucle infinie', url: baseUrl+'#blockly_controls_infiniteloop'},
-        {id: 'blockly_logic_operation', name: 'Opérateurs logiques', url: baseUrl+'#blockly_logic_operation'},
-        {id: 'extra_nested_repeat', name: 'Boucles imbriquées', url: baseUrl+'#extra_nested_repeat'},
-        {id: 'extra_variable', name: 'Variables', url: baseUrl+'#extra_variable'},
-        {id: 'extra_list', name: 'Listes', url: baseUrl+'#extra_list'},
-        {id: 'extra_function', name: 'Fonctions', url: baseUrl+'#extra_function'},
-        {id: 'robot_commands', name: 'Commandes du robot', url: baseUrl+'#robot_commands'},
-        {id: 'arguments', name: 'Fonctions avec arguments', url: baseUrl+'#arguments'}
+        {id: 'taskplatform', name: 'Résolution des exercices', url: baseUrl+'#taskplatform', language: 'all', order: 100},
+        {id: 'language', name: "Création d'un programme", url: baseUrl+'#language', order: 101},
+        {id: 'blockly_text_print', name: 'Afficher du texte', url: baseUrl+'#blockly_text_print', order: 102},
+        {id: 'blockly_text_print_noend', name: 'Afficher consécutivement du texte', url: baseUrl+'#blockly_text_print_noend', order: 103},
+        {id: 'blockly_controls_repeat', name: 'Boucles de répétition', url: baseUrl+'#blockly_controls_repeat', order: 104},
+        {id: 'blockly_controls_if', name: 'Conditions si', url: baseUrl+'#blockly_controls_if', order: 105},
+        {id: 'blockly_controls_if_else', name: 'Conditions si/sinon', url: baseUrl+'#blockly_controls_if_else', order: 106},
+        {id: 'blockly_controls_whileUntil', name: 'Boucles tant que ou jusqu\'à', url: baseUrl+'#blockly_controls_whileUntil', order: 107},
+        {id: 'blockly_controls_infiniteloop', name: 'Boucle infinie', url: baseUrl+'#blockly_controls_infiniteloop', order: 108},
+        {id: 'blockly_logic_operation', name: 'Opérateurs logiques', url: baseUrl+'#blockly_logic_operation', order: 109},
+        {id: 'extra_nested_repeat', name: 'Boucles imbriquées', url: baseUrl+'#extra_nested_repeat', order: 110},
+        {id: 'extra_variable', name: 'Variables', url: baseUrl+'#extra_variable', order: 111},
+        {id: 'extra_list', name: 'Listes', url: baseUrl+'#extra_list', order: 112},
+        {id: 'extra_function', name: 'Fonctions', url: baseUrl+'#extra_function', order: 113},
+        {id: 'robot_commands', name: 'Commandes du robot', url: baseUrl+'#robot_commands', order: 114},
+        {id: 'arguments', name: 'Fonctions avec arguments', url: baseUrl+'#arguments', order: 115}
         ];
     return baseConcepts;
 }

--- a/pemFioi/conceptViewer-1.0.js
+++ b/pemFioi/conceptViewer-1.0.js
@@ -214,22 +214,22 @@ function getConceptViewerBaseConcepts() {
     // Get base concepts in the default help
     var baseUrl = getConceptViewerBaseUrl();
     var baseConcepts = [
-        {id: 'taskplatform', name: 'Résolution des exercices', url: baseUrl+'#taskplatform', language: 'all'},
-        {id: 'language', name: "Création d'un programme", url: baseUrl+'#language'},
-        {id: 'blockly_text_print', name: 'Afficher du texte', url: baseUrl+'#blockly_text_print'},
-        {id: 'blockly_text_print_noend', name: 'Afficher consécutivement du texte', url: baseUrl+'#blockly_text_print_noend'},
-        {id: 'blockly_controls_repeat', name: 'Boucles de répétition', url: baseUrl+'#blockly_controls_repeat'},
-        {id: 'blockly_controls_if', name: 'Conditions si', url: baseUrl+'#blockly_controls_if'},
-        {id: 'blockly_controls_if_else', name: 'Conditions si/sinon', url: baseUrl+'#blockly_controls_if_else'},
-        {id: 'blockly_controls_whileUntil', name: 'Boucles tant que ou jusqu\'à', url: baseUrl+'#blockly_controls_whileUntil'},
-        {id: 'blockly_controls_infiniteloop', name: 'Boucle infinie', url: baseUrl+'#blockly_controls_infiniteloop'},
-        {id: 'blockly_logic_operation', name: 'Opérateurs logiques', url: baseUrl+'#blockly_logic_operation'},
-        {id: 'extra_nested_repeat', name: 'Boucles imbriquées', url: baseUrl+'#extra_nested_repeat'},
-        {id: 'extra_variable', name: 'Variables', url: baseUrl+'#extra_variable'},
-        {id: 'extra_list', name: 'Listes', url: baseUrl+'#extra_list'},
-        {id: 'extra_function', name: 'Fonctions', url: baseUrl+'#extra_function'},
-        {id: 'robot_commands', name: 'Commandes du robot', url: baseUrl+'#robot_commands'},
-        {id: 'arguments', name: 'Fonctions avec arguments', url: baseUrl+'#arguments'}
+        {id: 'taskplatform', name: 'Résolution des exercices', url: baseUrl+'#taskplatform', language: 'all', order: 100},
+        {id: 'language', name: "Création d'un programme", url: baseUrl+'#language', order: 101},
+        {id: 'blockly_text_print', name: 'Afficher du texte', url: baseUrl+'#blockly_text_print', order: 102},
+        {id: 'blockly_text_print_noend', name: 'Afficher consécutivement du texte', url: baseUrl+'#blockly_text_print_noend', order: 103},
+        {id: 'blockly_controls_repeat', name: 'Boucles de répétition', url: baseUrl+'#blockly_controls_repeat', order: 104},
+        {id: 'blockly_controls_if', name: 'Conditions si', url: baseUrl+'#blockly_controls_if', order: 105},
+        {id: 'blockly_controls_if_else', name: 'Conditions si/sinon', url: baseUrl+'#blockly_controls_if_else', order: 106},
+        {id: 'blockly_controls_whileUntil', name: 'Boucles tant que ou jusqu\'à', url: baseUrl+'#blockly_controls_whileUntil', order: 107},
+        {id: 'blockly_controls_infiniteloop', name: 'Boucle infinie', url: baseUrl+'#blockly_controls_infiniteloop', order: 108},
+        {id: 'blockly_logic_operation', name: 'Opérateurs logiques', url: baseUrl+'#blockly_logic_operation', order: 109},
+        {id: 'extra_nested_repeat', name: 'Boucles imbriquées', url: baseUrl+'#extra_nested_repeat', order: 110},
+        {id: 'extra_variable', name: 'Variables', url: baseUrl+'#extra_variable', order: 111},
+        {id: 'extra_list', name: 'Listes', url: baseUrl+'#extra_list', order: 112},
+        {id: 'extra_function', name: 'Fonctions', url: baseUrl+'#extra_function', order: 113},
+        {id: 'robot_commands', name: 'Commandes du robot', url: baseUrl+'#robot_commands', order: 114},
+        {id: 'arguments', name: 'Fonctions avec arguments', url: baseUrl+'#arguments', order: 115}
         ];
     return baseConcepts;
 }


### PR DESCRIPTION
We decided to put the documentation of basic concepts (loop, if_else...) before the functions specific to QuickPi or other lib.

These modifications put the order of basic concepts in 100+ (extacly in [100,115]). Since QuickPi is in 200+ then the basic concepts are displayed before QuickPi concepts.