### PR TITLE
[Algorea][ConceptViewer] Fixed crash when all standard blocks are available

### DIFF
--- a/pemFioi/conceptViewer-1.0-mobileFirst.js
+++ b/pemFioi/conceptViewer-1.0-mobileFirst.js
@@ -423,7 +423,7 @@ function getConceptsFromBlocks(includeBlocks, allConcepts, context) {
     var concepts = ['language'];
     if(includeBlocks.standardBlocks.includeAll) {
       for(var c = 0; c<allConcepts.length; c++) {
-        if(allConcepts[c].name.substr(0, 7) == 'blockly_') {
+        if(allConcepts[c].id.substr(0, 8) == 'blockly_') {
           concepts.push(allConcepts[c]);
         }
       }

--- a/pemFioi/conceptViewer-1.0-mobileFirst.js
+++ b/pemFioi/conceptViewer-1.0-mobileFirst.js
@@ -423,7 +423,7 @@ function getConceptsFromBlocks(includeBlocks, allConcepts, context) {
     var concepts = ['language'];
     if(includeBlocks.standardBlocks.includeAll) {
       for(var c = 0; c<allConcepts.length; c++) {
-        if(allConcepts[c].id.substr(0, 8) == 'blockly_') {
+        if(allConcepts[c].id.substr(0, 8) === 'blockly_') {
           concepts.push(allConcepts[c]);
         }
       }

--- a/pemFioi/conceptViewer-1.0.js
+++ b/pemFioi/conceptViewer-1.0.js
@@ -280,7 +280,7 @@ function getConceptsFromBlocks(includeBlocks, allConcepts, context) {
     var concepts = ['language'];
     if(includeBlocks.standardBlocks.includeAll) {
       for(var c = 0; c<allConcepts.length; c++) {
-        if(allConcepts[c].name.substr(0, 7) == 'blockly_') {
+        if(allConcepts[c].id.substr(0, 8) == 'blockly_') {
           concepts.push(allConcepts[c]);
         }
       }

--- a/pemFioi/conceptViewer-1.0.js
+++ b/pemFioi/conceptViewer-1.0.js
@@ -280,7 +280,7 @@ function getConceptsFromBlocks(includeBlocks, allConcepts, context) {
     var concepts = ['language'];
     if(includeBlocks.standardBlocks.includeAll) {
       for(var c = 0; c<allConcepts.length; c++) {
-        if(allConcepts[c].id.substr(0, 8) == 'blockly_') {
+        if(allConcepts[c].id.substr(0, 8) === 'blockly_') {
           concepts.push(allConcepts[c]);
         }
       }


### PR DESCRIPTION
When all standards blocks are available and we want to display documentation, then the hole program crash.

I have changed .name to .id instead because in standard blocks, the "name" key does not make very sens to use it in code. And I also have changed 7 to 8, because in the function substr, the second value is the length, if we put 7 it will just get "blockly" without the needed '_', so we must increase by one in order to make it work.