### PR TITLE
[QuickPi][Function] Fixed function drawRectangle with stroke

### DIFF
--- a/pemFioi/quickpi/blocklyQuickPi_screen.js
+++ b/pemFioi/quickpi/blocklyQuickPi_screen.js
@@ -189,13 +189,14 @@ class screenDrawing {
         _drawRectangle(canvas, scale, x0, y0, width, height) {
             var ctx = canvas.getContext('2d');
 
+            if (!this.noFillStatus) {
+                ctx.fillRect(scale * x0, scale * y0, scale * width, scale * height);
+            }
+
             if (!this.noStrokeStatus) {
                 ctx.strokeRect(scale * x0, scale * y0, scale * width, scale * height);
             }
 
-            if (!this.noFillStatus) {
-                ctx.fillRect(scale * x0, scale * y0, scale * width, scale * height);
-            }
         }
 
         drawRectangle(x0, y0, width, height) {


### PR DESCRIPTION
There was a bug with the size of the border with stroke and fill. Like if we put fill(0), and the noStroke(), the border between two rectangles are of size different.

Normally between resolutions, according to Pable, pixels for the border of rectangles are of size 0.5, 1, 2. With this bug, when we use fill, it was of size 1, but with noStroke(), it was of size 2, so the user can see a thick difference between this too.

With this fix, the two borders are of a correct size.