### PR TITLE
[QuickPi][Fr] Changed french block of fill

### DIFF
--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -56,7 +56,7 @@ var quickPiLocalLanguageStrings = {
             updateScreen: "mettre à jour l'écran",
             autoUpdate: "mode de mise à jour automatique de l'écran",
 
-            fill: "mettre la couleur de fond à %1",
+            fill: "mettre la couleur de remplissage à %1",
             noFill: "ne pas remplir les formes",
             stroke: "mettre la couleur de tracé à %1",
             noStroke: "ne pas dessiner les contours",


### PR DESCRIPTION
I have changed the translation according to the conversation of slack.

This one is better because it was called "changer la couleur de fond", but the opposit one is called "ne pas remplir les formes", which has not very much sense, moreover, this function change only the background of circles and rectangles that the user draw and not the background of the screen.