### PR TITLE
[QuickPi][Function] Fixed button was pressed error

### DIFF
--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -8357,7 +8357,7 @@ var getContext = function (display, infos, curLevel) {
         if (!context.display || context.autoGrading || context.offLineMode) {
             var state = context.getSensorState(name);
 
-            var wasPressed = sensor.wasPressed;
+            var wasPressed = !!sensor.wasPressed;
             sensor.wasPressed = false;
 
             context.runner.noDelay(callback, wasPressed);


### PR DESCRIPTION
The function was supposed to return a boolean, but in some cases it returns "null", I put the !! operator to make sure that it return a boolean every time.

The problem is that if it returns null, then there is a null exception for drawline with this code:
displayText(buttonWasPressed("button1"), "")