### PR TITLE
Quickpi scrollbar fix

### DIFF
--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -5915,7 +5915,10 @@ var getContext = function (display, infos, curLevel) {
                 var percentage = 1 - ((newy - sliderobj.sliderdata.insiderecty) / sliderobj.sliderdata.scale);
 
                 if (Array.isArray(sensor.state)) {
-                    sensor.state[sliderobj.index] = findSensorDefinition(sensor).getStateFromPercentage(percentage);
+                    if (sensor.reverseSlider)
+                        sensor.state[Math.abs(sliderobj.index + 1 - sensor.sliders.length)] = findSensorDefinition(sensor).getStateFromPercentage(percentage);
+                    else
+                        sensor.state[sliderobj.index] = findSensorDefinition(sensor).getStateFromPercentage(percentage);
                 } else {
                     sensor.state = findSensorDefinition(sensor).getStateFromPercentage(percentage);
                 }
@@ -5942,13 +5945,15 @@ var getContext = function (display, infos, curLevel) {
                         continue;
 
                     var percentage = findSensorDefinition(sensor).getPercentageFromState(sensor.state[i], sensor);
+                    var Isensor = i;
+                    if (sensor.reverseSlider)
+                        Isensor = Math.abs(i + 1 - sensor.state.length);
+                    thumby = sensor.sliders[Isensor].sliderdata.insiderecty +
+                        sensor.sliders[Isensor].sliderdata.insideheight -
+                        sensor.sliders[Isensor].sliderdata.thumbheight -
+                        (percentage * sensor.sliders[Isensor].sliderdata.scale);
 
-                    thumby = sensor.sliders[i].sliderdata.insiderecty +
-                        sensor.sliders[i].sliderdata.insideheight -
-                        sensor.sliders[i].sliderdata.thumbheight -
-                        (percentage * sensor.sliders[i].sliderdata.scale);
-
-                    sensor.sliders[i].thumb.attr('y', thumby);
+                    sensor.sliders[Isensor].thumb.attr('y', thumby);
                 }
             } else {
                 var percentage = findSensorDefinition(sensor).getPercentageFromState(sensor.state, sensor);
@@ -6023,21 +6028,38 @@ var getContext = function (display, infos, curLevel) {
                     offset = sensor.drawInfo.width * .70;
                 }
 
-
-                for (var i = 0; i < sensor.state.length; i++) {
-                    sliderobj = createSlider(sensor,
-                        max,
-                        min,
-                        sensor.drawInfo.x + offset + (sign * i * sensor.drawInfo.height / 5) ,
-                        sensor.drawInfo.y,
-                        sensor.drawInfo.height,
-                        sensor.drawInfo.height,
-                        i);
+                // if offset is equal to 0, we need to reverse
+                if (offset == 0) {
+                    sensor.reverseSlider = true;
+                    for (var i = sensor.state.length - 1; i >= 0; i--) {
+                        var sliderobj = createSlider(sensor,
+                            max,
+                            min,
+                            sensor.drawInfo.x + offset + (sign * i * sensor.drawInfo.height / 5),
+                            sensor.drawInfo.y,
+                            sensor.drawInfo.height,
+                            sensor.drawInfo.height,
+                            i);
+                        sensor.sliders.unshift(sliderobj);
+                    }
+                }
+                else {
+                    sensor.reverseSlider = false;
+                    for (var i = 0; i < sensor.state.length; i++) {
+                        var sliderobj = createSlider(sensor,
+                            max,
+                            min,
+                            sensor.drawInfo.x + offset + (sign * i * sensor.drawInfo.height / 5),
+                            sensor.drawInfo.y,
+                            sensor.drawInfo.height,
+                            sensor.drawInfo.height,
+                            i);
 
                         sensor.sliders.push(sliderobj);
+                    }
                 }
             } else {
-                sliderobj = createSlider(sensor,
+                var sliderobj = createSlider(sensor,
                     max,
                     min,
                     sensor.drawInfo.x,

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -5915,10 +5915,7 @@ var getContext = function (display, infos, curLevel) {
                 var percentage = 1 - ((newy - sliderobj.sliderdata.insiderecty) / sliderobj.sliderdata.scale);
 
                 if (Array.isArray(sensor.state)) {
-                    if (sensor.reverseSlider)
-                        sensor.state[Math.abs(sliderobj.index + 1 - sensor.sliders.length)] = findSensorDefinition(sensor).getStateFromPercentage(percentage);
-                    else
-                        sensor.state[sliderobj.index] = findSensorDefinition(sensor).getStateFromPercentage(percentage);
+                    sensor.state[sliderobj.index] = findSensorDefinition(sensor).getStateFromPercentage(percentage);
                 } else {
                     sensor.state = findSensorDefinition(sensor).getStateFromPercentage(percentage);
                 }
@@ -5945,15 +5942,13 @@ var getContext = function (display, infos, curLevel) {
                         continue;
 
                     var percentage = findSensorDefinition(sensor).getPercentageFromState(sensor.state[i], sensor);
-                    var Isensor = i;
-                    if (sensor.reverseSlider)
-                        Isensor = Math.abs(i + 1 - sensor.state.length);
-                    thumby = sensor.sliders[Isensor].sliderdata.insiderecty +
-                        sensor.sliders[Isensor].sliderdata.insideheight -
-                        sensor.sliders[Isensor].sliderdata.thumbheight -
-                        (percentage * sensor.sliders[Isensor].sliderdata.scale);
 
-                    sensor.sliders[Isensor].thumb.attr('y', thumby);
+                    thumby = sensor.sliders[i].sliderdata.insiderecty +
+                        sensor.sliders[i].sliderdata.insideheight -
+                        sensor.sliders[i].sliderdata.thumbheight -
+                        (percentage * sensor.sliders[i].sliderdata.scale);
+
+                    sensor.sliders[i].thumb.attr('y', thumby);
                 }
             } else {
                 var percentage = findSensorDefinition(sensor).getPercentageFromState(sensor.state, sensor);
@@ -6030,21 +6025,20 @@ var getContext = function (display, infos, curLevel) {
 
                 // if offset is equal to 0, we need to reverse
                 if (offset == 0) {
-                    sensor.reverseSlider = true;
-                    for (var i = sensor.state.length - 1; i >= 0; i--) {
+                    for (var i = 0; i < sensor.state.length; i++) {
                         var sliderobj = createSlider(sensor,
                             max,
                             min,
-                            sensor.drawInfo.x + offset + (sign * i * sensor.drawInfo.height / 5),
+                            sensor.drawInfo.x + offset + (sign * Math.abs(i + 1 - sensor.state.length) * sensor.drawInfo.height / 5),
                             sensor.drawInfo.y,
                             sensor.drawInfo.height,
                             sensor.drawInfo.height,
                             i);
-                        sensor.sliders.unshift(sliderobj);
+
+                        sensor.sliders.push(sliderobj);
                     }
                 }
                 else {
-                    sensor.reverseSlider = false;
                     for (var i = 0; i < sensor.state.length; i++) {
                         var sliderobj = createSlider(sensor,
                             max,


### PR DESCRIPTION
This branch allow us to fix this bug:

When the scrollbar for sensors which more than one bar (magneto, gyroscope) is at left, then when we move the left scrollbar, the z is moving instead of the x axis.

With this fix, it put the scrollbars in the correct order (x, y, z)