### PR TITLE
Fix microphone zero

### DIFF
--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -7180,7 +7180,7 @@ var getContext = function (display, infos, curLevel) {
 
             // if we just do sensor.state, if it is equal to 0 then the state is not displayed
             if (sensor.state != null) {
-                sensor.stateText = paper.text(state1x, state1y, sensor.state + "dB");
+                sensor.stateText = paper.text(state1x, state1y, sensor.state + " dB");
             }
 
             if (!context.autoGrading && context.offLineMode) {

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -7178,11 +7178,9 @@ var getContext = function (display, infos, curLevel) {
                 "opacity": fadeopacity,
             });
 
-            if (sensor.stateText)
-                sensor.stateText.remove();
-
-            if (sensor.state) {
-                sensor.stateText = paper.text(state1x, state1y, sensor.state);
+            // if we just do sensor.state, if it is equal to 0 then the state is not displayed
+            if (sensor.state != null) {
+                sensor.stateText = paper.text(state1x, state1y, sensor.state + "dB");
             }
 
             if (!context.autoGrading && context.offLineMode) {


### PR DESCRIPTION
There was a bug:

In the simulation, when the dropdown of the sound reaches 0, the text to display the sound level disapear, it was due to the fact that we do an if (sensor.state), but if sensor.state is equal to 0, then it return false and does not display the text.

The unit was also missing for the sound (dB), so I added it.

There was also a duplicate of the removal of the state (it is removed at the begining of the if and after, so I removed the duplicate).