### PR TITLE
Quickpi gettemperature

### DIFF
--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -8834,23 +8834,25 @@ var getContext = function (display, infos, curLevel) {
 
 
     // TODO: change url to the "prod" one
-    context.quickpi.getTemperatureFromCloudUrl = "https://mapadev.com/nicolastest/weather.php";
+    var getTemperatureFromCloudURl = "https://mapadev.com/nicolastest/weather.php";
+
+    var getTemperatureFromCloudSupportedTowns = [];
 
     // setup the supported towns
-    $.get(context.quickpi.getTemperatureFromCloudUrl + "?q=" + "supportedtowns", function(towns) {
-        context.quickpi.getTemperatureFromCloudSupportedTowns = JSON.parse(towns);
+    $.get(getTemperatureFromCloudURl + "?q=" + "supportedtowns", function(towns) {
+        getTemperatureFromCloudSupportedTowns = JSON.parse(towns);
     });
 
     // We create a cache so there is less calls to the api and we get the results of the temperature faster
-    context.quickpi._getTemperatureFromCloudCache = {};
+    var getTemperatureFromCloudCache = {};
 
     context.quickpi.getTemperatureFromCloud = function(location, callback) {
-        var url = context.quickpi.getTemperatureFromCloudUrl;
+        var url = getTemperatureFromCloudURl;
 
-        if (!arrayContains(context.quickpi.getTemperatureFromCloudSupportedTowns, location))
+        if (!arrayContains(getTemperatureFromCloudSupportedTowns, location))
             throw strings.messages.getTemperatureFromCloudWrongValue.format(location);
 
-        var cache = context.quickpi._getTemperatureFromCloudCache;
+        var cache = getTemperatureFromCloudCache;
         if (cache[location] != undefined && ((Date.now() - cache[location].lastUpdate) / 1000) / 60 < 10) {
             context.waitDelay(callback, cache[location].temperature);
             return;

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -378,7 +378,7 @@ var quickPiLocalLanguageStrings = {
             cloudUnexpectedKey: "La clé {0} n'est pas une clé attendue",
             hello: "Bonjour",
 
-            getTemperatureWrongValue: "getTemperatureFromCloud: {0} n'est pas une ville supportée par getTemperatureFromCloud",
+            getTemperatureFromCloudWrongValue: "getTemperatureFromCloud: {0} n'est pas une ville supportée par getTemperatureFromCloud",
 
             experiment: "Expérimenter",
             validate: "Valider",
@@ -749,7 +749,7 @@ var quickPiLocalLanguageStrings = {
             irEnableContinous: "Activar la emisión IR continua",
             irDisableContinous: "Desactivar la emisión IR continua",
 
-            getTemperatureWrongValue: "getTemperatureFromCloud: {0} is not a town supported by getTemperatureFromCloud", // TODO: translate
+            getTemperatureFromCloudWrongValue: "getTemperatureFromCloud: {0} is not a town supported by getTemperatureFromCloud", // TODO: translate
 
             up: "arriba",
             down: "abajo",
@@ -1186,7 +1186,7 @@ var quickPiLocalLanguageStrings = {
             on: "On",
             off: "Off",
 
-            getTemperatureWrongValue: "getTemperatureFromCloud: {0} is not a town supported by getTemperatureFromCloud", // TODO: translate
+            getTemperatureFromCloudWrongValue: "getTemperatureFromCloud: {0} is not a town supported by getTemperatureFromCloud", // TODO: translate
 
             grovehat: "Grove Base Hat for Raspberry Pi",
             quickpihat: "France IOI QuickPi Hat",
@@ -8865,7 +8865,7 @@ var getContext = function (display, infos, curLevel) {
         var url = context.quickpi.getTemperatureFromCloudUrl;
 
         if (!context.quickpi.getTemperatureFromCloudSupportedTowns.includes(location))
-            throw strings.messages.getTemperatureWrongValue.format(location);
+            throw strings.messages.getTemperatureFromCloudWrongValue.format(location);
 
         var cache = context.quickpi.getTemperatureFromCloudCache;
         for (var i = 0; i < cache.length; i++) {
@@ -10183,7 +10183,7 @@ var getContext = function (display, infos, curLevel) {
                 {
                     name: "getTemperatureFromCloud", yieldsValue: true, params: ["String"], blocklyJson: {
                         "args0": [
-                            { "type": "field_input", "name": "PARAM_0", text: "Paris, France"},
+                            { "type": "field_input", "name": "PARAM_0", text: "Paris"},
                         ]
                     },
                     blocklyXml: "<block type='getTemperatureFromCloud'>" +

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -8862,6 +8862,8 @@ var getContext = function (display, infos, curLevel) {
         $.get(url + "?q=" + location, function(data) {
             // If the server return invalid it mean that the town given is not supported
             if (data === "invalid") {
+                // This only happen when the user give an invalid town to the server, which should never happen because
+                // the validity of the user input is checked above.
                 cb(0);
             } else {
                 cache[location] = {

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -36,7 +36,7 @@ var quickPiLocalLanguageStrings = {
             displayText2Lines: "afficher Ligne 1 : %1 Ligne 2 : %2",
 
             readTemperature: "température ambiante",
-            getTemperature: "temperature de %1",
+            getTemperatureFromCloud: "temperature de la ville %1",
 
             readRotaryAngle: "état du potentiomètre %1",
             readDistance: "distance mesurée par %1",
@@ -108,7 +108,7 @@ var quickPiLocalLanguageStrings = {
             readLightIntensity: "readLightIntensity",
             readHumidity: "readHumidity",
             currentTime: "currentTime",
-            getTemperature: "getTemperature",
+            getTemperatureFromCloud: "getTemperatureFromCloud",
 
             isLedOn: "isLedOn",
             isLedOnWithName: "isLedOn",
@@ -209,7 +209,7 @@ var quickPiLocalLanguageStrings = {
             setBuzzerNote: "setBuzzerNote(buzzer, frequency) fait sonner le buzzer à la fréquence indiquée",
             getBuzzerNote: "getBuzzerNote(buzzer) retourne la fréquence actuelle du buzzer",
 
-            getTemperature: "getTemperature(thermometer) ",
+            getTemperatureFromCloud: "getTemperatureFromCloud(town) retourne la température dans la ville donnée",
 
             drawPoint: "drawPoint(x, y)",
             isPointSet: "isPointSet(x, y)",
@@ -378,7 +378,7 @@ var quickPiLocalLanguageStrings = {
             cloudUnexpectedKey: "La clé {0} n'est pas une clé attendue",
             hello: "Bonjour",
 
-            getTemperatureWrongValue: "getTemperature: {0} n'est pas une ville supportée par getTemperature",
+            getTemperatureWrongValue: "getTemperatureFromCloud: {0} n'est pas une ville supportée par getTemperatureFromCloud",
 
             experiment: "Expérimenter",
             validate: "Valider",
@@ -467,7 +467,7 @@ var quickPiLocalLanguageStrings = {
             displayText2Lines: "desplegar texto Linea 1 : %1 Linea 2 : %2",
 
             readTemperature: "temperatura ambiente",
-            getTemperature: "temperatura de %1",
+            getTemperatureFromCloud: "temperatura de la ciudad %1", // TODO: verify
 
             readRotaryAngle: "estado del potenciómetro %1",
             readDistance: "distancia medida por %1",
@@ -539,7 +539,7 @@ var quickPiLocalLanguageStrings = {
             readLightIntensity: "readLightIntensity",
             readHumidity: "readHumidity",
             currentTime: "currentTime",
-            getTemperature: "getTemperature",
+            getTemperatureFromCloud: "getTemperatureFromCloud",
 
             isLedOn: "isLedOn",
             isLedOnWithName: "isLedOn",
@@ -640,7 +640,7 @@ var quickPiLocalLanguageStrings = {
             setBuzzerNote: "setBuzzerNote(buzzer, frequency) suena el zumbador en la frecuencia indicada",
             getBuzzerNote: "getBuzzerNote(buzzer) devuelve la frecuencia actual del zumbador",
 
-            getTemperature: "getTemperature(thermometer) obtiene la temperatura del sensor",
+            getTemperatureFromCloud: "getTemperatureFromCloud(town) obtiene la temperatura de la ciudad", // TODO: Verify
 
             drawPoint: "drawPoint(x, y) dibuja un punto en las coordenadas x, y",
             isPointSet: "isPointSet(x, y) devuelve True se dibujó sobre el punto x, y, False de lo contrario",
@@ -749,7 +749,7 @@ var quickPiLocalLanguageStrings = {
             irEnableContinous: "Activar la emisión IR continua",
             irDisableContinous: "Desactivar la emisión IR continua",
 
-            getTemperatureWrongValue: "getTemperature: {0} is not a town supported by getTemperature", // TODO: translate
+            getTemperatureWrongValue: "getTemperatureFromCloud: {0} is not a town supported by getTemperatureFromCloud", // TODO: translate
 
             up: "arriba",
             down: "abajo",
@@ -893,7 +893,7 @@ var quickPiLocalLanguageStrings = {
             displayText2Lines: "mostra Riga 1 : %1 Riga 2 : %2",
 
             readTemperature: "temperatura ambiente",
-            getTemperature: "temperatura di %1",
+            getTemperatureFromCloud: "temperatura della cità %1", // TODO: verify
 
             readRotaryAngle: "stato del potenziometro %1",
             readDistance: "distanza misurata all'%1",
@@ -965,7 +965,7 @@ var quickPiLocalLanguageStrings = {
             readLightIntensity: "readLightIntensity",
             readHumidity: "readHumidity",
             currentTime: "currentTime",
-            getTemperature: "getTemperature",
+            getTemperatureFromCloud: "getTemperatureFromCloud",
 
             isLedOn: "isLedOn",
             isLedOnWithName: "isLedOn",
@@ -1066,7 +1066,7 @@ var quickPiLocalLanguageStrings = {
             setBuzzerNote: "setBuzzerNote(buzzer, frequency) fa suonare il cicalino alla frequenza indicata",
             getBuzzerNote: "getBuzzerNote(buzzer) riporta la frequenza attuale del cicalino",
 
-            getTemperature: "getTemperature(thermometer) ",
+            getTemperatureFromCloud: "getTemperatureFromCloud(town) get the temperature from the town given", // TODO: Translate
 
             drawPoint: "drawPoint(x, y)",
             isPointSet: "isPointSet(x, y)",
@@ -1186,7 +1186,7 @@ var quickPiLocalLanguageStrings = {
             on: "On",
             off: "Off",
 
-            getTemperatureWrongValue: "getTemperature: {0} is not a town supported by getTemperature", // TODO: translate
+            getTemperatureWrongValue: "getTemperatureFromCloud: {0} is not a town supported by getTemperatureFromCloud", // TODO: translate
 
             grovehat: "Grove Base Hat for Raspberry Pi",
             quickpihat: "France IOI QuickPi Hat",
@@ -1312,7 +1312,7 @@ var quickPiLocalLanguageStrings = {
             currentTime: "returns current time",
             setBuzzerState: "sonnerie",
             setBuzzerNote: "sonnerie note",
-            getTemperature: "Get temperature",
+            getTemperatureFromCloud: "Get temperature from town",
             setBuzzerNote: "Set buzzer note",
             getBuzzerNote: "Get buzzer note",
             setLedBrightness: "Set Led Brightness",
@@ -1716,7 +1716,7 @@ var getContext = function (display, infos, curLevel) {
             {
                 id: 'quickpi_cloud',
                 order: 220,
-                python: ['writeToCloudStore','connectToCloudStore','readFromCloudStore']
+                python: ['writeToCloudStore','connectToCloudStore','readFromCloudStore', 'getTemperatureFromCloud']
             }
         ];
 
@@ -8834,19 +8834,19 @@ var getContext = function (display, infos, curLevel) {
 
 
     // TODO: change url to the "prod" one
-    context.quickpi.getTemperatureUrl = "https://mapadev.com/nicolastest/weather.php";
+    context.quickpi.getTemperatureFromCloudUrl = "https://mapadev.com/nicolastest/weather.php";
 
     // setup the supported towns
-    $.get(context.quickpi.getTemperatureUrl + "?q=" + "supportedtowns", function(towns) {
-        context.quickpi.getTemperatureSupportedTowns = towns;
+    $.get(context.quickpi.getTemperatureFromCloudUrl + "?q=" + "supportedtowns", function(towns) {
+        context.quickpi.getTemperatureFromCloudSupportedTowns = towns;
     });
 
     // We create a cache so there is less calls to the api and we get the results of the temperature faster
-    context.quickpi.getTemperatureCache = [];
+    context.quickpi.getTemperatureFromCloudCache = [];
 
-    context.quickpi.getTemperature = function(location, callback) {
+    context.quickpi.getTemperatureFromCloud = function(location, callback) {
 
-        function _updateGetTemperatureCache(cache, location, newVal) {
+        function _updateGetTemperatureFromCloudCache(cache, location, newVal) {
             for (var i = 0; i < cache.length; i++) {
                 var curr = cache[i];
                 if (curr.location === location) {
@@ -8862,12 +8862,12 @@ var getContext = function (display, infos, curLevel) {
             });
         }
 
-        var url = context.quickpi.getTemperatureUrl;
+        var url = context.quickpi.getTemperatureFromCloudUrl;
 
-        if (!context.quickpi.getTemperatureSupportedTowns.includes(location))
+        if (!context.quickpi.getTemperatureFromCloudSupportedTowns.includes(location))
             throw strings.messages.getTemperatureWrongValue.format(location);
 
-        var cache = context.quickpi.getTemperatureCache;
+        var cache = context.quickpi.getTemperatureFromCloudCache;
         for (var i = 0; i < cache.length; i++) {
             var curr = cache[i];
             if (curr.location === location) {
@@ -8886,7 +8886,7 @@ var getContext = function (display, infos, curLevel) {
             if (data === "invalid") {
                 cb(0);
             } else {
-                _updateGetTemperatureCache(cache, location, data);
+                _updateGetTemperatureFromCloudCache(cache, location, data);
 
                 cb(data);
             }
@@ -10181,11 +10181,14 @@ var getContext = function (display, infos, curLevel) {
             ],
             internet: [
                 {
-                    name: "getTemperature", yieldsValue: true, params: ["String"], blocklyJson: {
+                    name: "getTemperatureFromCloud", yieldsValue: true, params: ["String"], blocklyJson: {
                         "args0": [
                             { "type": "field_input", "name": "PARAM_0", text: "Paris, France"},
                         ]
                     },
+                    blocklyXml: "<block type='getTemperatureFromCloud'>" +
+                        "<value name='PARAM_0'><shadow type='text'><field name='TEXT'></field> </shadow></value>" +
+                        "</block>"
                 },
                 {
                     name: "connectToCloudStore", params: ["String", "String"], blocklyJson: {

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -8838,7 +8838,7 @@ var getContext = function (display, infos, curLevel) {
 
     // setup the supported towns
     $.get(context.quickpi.getTemperatureFromCloudUrl + "?q=" + "supportedtowns", function(towns) {
-        context.quickpi.getTemperatureFromCloudSupportedTowns = towns;
+        context.quickpi.getTemperatureFromCloudSupportedTowns = JSON.parse(towns);
     });
 
     // We create a cache so there is less calls to the api and we get the results of the temperature faster
@@ -8864,7 +8864,7 @@ var getContext = function (display, infos, curLevel) {
 
         var url = context.quickpi.getTemperatureFromCloudUrl;
 
-        if (!context.quickpi.getTemperatureFromCloudSupportedTowns.includes(location))
+        if (!arrayContains(context.quickpi.getTemperatureFromCloudSupportedTowns, location))
             throw strings.messages.getTemperatureFromCloudWrongValue.format(location);
 
         var cache = context.quickpi.getTemperatureFromCloudCache;

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -8841,6 +8841,8 @@ var getContext = function (display, infos, curLevel) {
         context.quickpi.getTemperatureSupportedTowns = towns;
     });
 
+    
+
     context.quickpi.getTemperature = function(location, callback) {
         var url = context.quickpi.getTemperatureUrl;
 


### PR DESCRIPTION
This branch allow us to get the temperature of a town.

It connect to a server of dev currently, (need to be changed to the "prod" server).

In this modification, if we are in simulation but connected to the rasbery, it use the same code as if we were not (no need to access to sensors, just to the php api I coded).

The code is implemented in python in the file ext/quickpi.js for the board and inside of quickpi_lib for the simulation.

In both version, I have created an array containing all supported towns and if the town given is not in this array, it does not do the request and throw an error saying that the value is not supported. In the board, I did not knew how to throw an error correctly, so I just returned "Not supported town".

Also in both version I have a cache of values which is refreshed every 10 minutes, in order to do less API calls and get the value faster since anyway in the server, the value is updated only every hour (more or less depending on the configuration you have setted up in the server).

The php server have another security: if you try to send a non supported town, your request return "invalid".