### PR TITLE
Edit exercice2

### DIFF
--- a/pemFioi/quickAlgo/blockly_interface.js
+++ b/pemFioi/quickAlgo/blockly_interface.js
@@ -495,6 +495,9 @@ function getBlocklyInterface(maxBlocks, nbTestCases) {
                this.mainContext.saveAdditional(additional);
             }
 
+            if (this.quickAlgoInterface.saveSubject)
+               this.quickAlgoInterface.saveSubject(additional);
+
             var additionalNode = document.createElement("additional");
             additionalNode.innerText = JSON.stringify(additional);
             xml.appendChild(additionalNode);

--- a/pemFioi/quickAlgo/blockly_interface.js
+++ b/pemFioi/quickAlgo/blockly_interface.js
@@ -491,10 +491,6 @@ function getBlocklyInterface(maxBlocks, nbTestCases) {
             // subject title when edition is enabled...
             var additional = {};
 
-            if (this.mainContext.saveAdditional) {
-               this.mainContext.saveAdditional(additional);
-            }
-
             if (this.quickAlgoInterface.saveSubject)
                this.quickAlgoInterface.saveSubject(additional);
 
@@ -518,8 +514,9 @@ function getBlocklyInterface(maxBlocks, nbTestCases) {
             var additionalXML = xml.getElementsByTagName("additional");
             if (additionalXML.length > 0) {
                var additional = JSON.parse(additionalXML[0].innerText);
-               if (this.mainContext.loadAdditional) {
-                  this.mainContext.loadAdditional(additional);
+               // load additional from quickAlgoInterface
+               if (this.quickAlgoInterface.loadAdditional) {
+                  this.quickAlgoInterface.loadAdditional(additional);
                }
             }
          }

--- a/pemFioi/quickAlgo/blockly_interface.js
+++ b/pemFioi/quickAlgo/blockly_interface.js
@@ -491,8 +491,8 @@ function getBlocklyInterface(maxBlocks, nbTestCases) {
             // subject title when edition is enabled...
             var additional = {};
 
-            if (this.quickAlgoInterface.saveSubject)
-               this.quickAlgoInterface.saveSubject(additional);
+            if (this.quickAlgoInterface.saveAdditional)
+               this.quickAlgoInterface.saveAdditional(additional);
 
             var additionalNode = document.createElement("additional");
             additionalNode.innerText = JSON.stringify(additional);

--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -65,6 +65,8 @@ var quickAlgoLanguageStrings = {
       editWindowTitle: "Édition d'exercice",
       titleEdition: "Titre :",
       descriptionEdition: "Description :",
+      saveAndQuit: "Sauvegarder & Quitter",
+      quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?",
       avoidReloadingOtherTask: "Attention : ne rechargez pas le programme d'un autre sujet !",
       files: "Fichiers",
       reloadProgram: "Recharger",
@@ -192,6 +194,8 @@ var quickAlgoLanguageStrings = {
       editWindowTitle: "Exercise edition",
       titleEdition: "Title:",
       descriptionEdition: "Description:",
+      saveAndQuit: "Save & Quit",
+      quitWithoutSavingConfirmation: "Quit without saving your modifications ?",
       avoidReloadingOtherTask: "Warning: do not reload code for another task!",
       files: "Files",
       reloadProgram: "Reload",
@@ -320,6 +324,8 @@ var quickAlgoLanguageStrings = {
       editWindowTitle: "Übungsausgabe", // TODO: verify
       titleEdition: "Titel:", // TODO: verify
       descriptionEdition: "Beschreibung:", // TODO: verify
+      saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
+      quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       avoidReloadingOtherTask: "Warnung: Lade keinen Quelltext von einer anderen Aufgabe!",
       files: "Dateien",
       reloadProgram: "Laden",
@@ -449,6 +455,8 @@ var quickAlgoLanguageStrings = {
       editWindowTitle: "Edición de ejercicio", // TODO: verify
       titleEdition: "Título:", // TODO: verify
       descriptionEdition: "Descripción:", // TODO: verify
+      saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
+      quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       avoidReloadingOtherTask: "Atención: ¡no recargue el programa de otro problema!",
       files: "Archivos",
       reloadProgram: "Recargar",
@@ -576,6 +584,8 @@ var quickAlgoLanguageStrings = {
       editWindowTitle: "Izdaja vaje", // TODO: verify
       titleEdition: "Naslov:", // TODO: verify
       descriptionEdition: "Opis:", // TODO: verify
+      saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
+      quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       avoidReloadingOtherTask: "Opozorilo: Za drugo nalogo ne naloži kode znova!",
       files: "Datoteke",
       reloadProgram: "Znova naloži",
@@ -705,6 +715,8 @@ var quickAlgoLanguageStrings = {
       editWindowTitle: "Edizione esercizio", // TODO: verify
       titleEdition: "Titolo:", // TODO: verify
       descriptionEdition: "Descrizione:", // TODO: verify
+      saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
+      quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       avoidReloadingOtherTask: "Attenzione: non ricaricare il programma di un altro argomento!",
       files: "File",
       reloadProgram: "Ricarica",

--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -61,6 +61,10 @@ var quickAlgoLanguageStrings = {
       loadExample: "Insérer l'exemple",
       saveOrLoadButton: "Charger / enregistrer",
       saveOrLoadProgram: "Enregistrer ou recharger votre programme :",
+      editButton: "Editer",
+      editWindowTitle: "Édition d'exercice",
+      titleEdition: "Titre :",
+      descriptionEdition: "Description :",
       avoidReloadingOtherTask: "Attention : ne rechargez pas le programme d'un autre sujet !",
       files: "Fichiers",
       reloadProgram: "Recharger",
@@ -184,6 +188,10 @@ var quickAlgoLanguageStrings = {
       loadExample: "Insert example",
       saveOrLoadButton: "Load / save",
       saveOrLoadProgram: "Save or reload your code:",
+      editButton: "edit",
+      editWindowTitle: "Exercise edition",
+      titleEdition: "Title:",
+      descriptionEdition: "Description:",
       avoidReloadingOtherTask: "Warning: do not reload code for another task!",
       files: "Files",
       reloadProgram: "Reload",
@@ -308,6 +316,10 @@ var quickAlgoLanguageStrings = {
       loadExample: "Beispiel einfügen",
       saveOrLoadButton: "Laden / Speichern",
       saveOrLoadProgram: "Speicher oder lade deinen Quelltext:",
+      editButton: "bearbeiten", // TODO: verify
+      editWindowTitle: "Übungsausgabe", // TODO: verify
+      titleEdition: "Titel:", // TODO: verify
+      descriptionEdition: "Beschreibung:", // TODO: verify
       avoidReloadingOtherTask: "Warnung: Lade keinen Quelltext von einer anderen Aufgabe!",
       files: "Dateien",
       reloadProgram: "Laden",
@@ -433,6 +445,10 @@ var quickAlgoLanguageStrings = {
       loadExample: "Cargar el ejemplo",
       saveOrLoadButton: "Cargar / Guardar",
       saveOrLoadProgram: "Guardar o cargar su programa:",
+      editButton: "editar", // TODO: verify
+      editWindowTitle: "Edición de ejercicio", // TODO: verify
+      titleEdition: "Título:", // TODO: verify
+      descriptionEdition: "Descripción:", // TODO: verify
       avoidReloadingOtherTask: "Atención: ¡no recargue el programa de otro problema!",
       files: "Archivos",
       reloadProgram: "Recargar",
@@ -556,6 +572,10 @@ var quickAlgoLanguageStrings = {
       loadExample: "Naloži primer",
       saveOrLoadButton: "Naloži / Shrani",
       saveOrLoadProgram: "Shrani ali znova naloži kodo:",
+      editButton: "Uredi", // TODO: verify
+      editWindowTitle: "Izdaja vaje", // TODO: verify
+      titleEdition: "Naslov:", // TODO: verify
+      descriptionEdition: "Opis:", // TODO: verify
       avoidReloadingOtherTask: "Opozorilo: Za drugo nalogo ne naloži kode znova!",
       files: "Datoteke",
       reloadProgram: "Znova naloži",
@@ -681,6 +701,10 @@ var quickAlgoLanguageStrings = {
       loadExample: "Inserisci l'esempio",
       saveOrLoadButton: "Carica / salva",
       saveOrLoadProgram: "Salva o ricarica il tuo programma:",
+      editButton: "modificare", // TODO: verify
+      editWindowTitle: "Edizione esercizio", // TODO: verify
+      titleEdition: "Titolo:", // TODO: verify
+      descriptionEdition: "Descrizione:", // TODO: verify
       avoidReloadingOtherTask: "Attenzione: non ricaricare il programma di un altro argomento!",
       files: "File",
       reloadProgram: "Ricarica",

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -216,6 +216,7 @@ var quickAlgoInterface = {
                         "<span class='fas fa-upload'></span> " +
                         this.strings.reloadProgram +
                     "</div>" +
+                    "<div rel='edit' class='item' onclick='quickAlgoInterface.editorBtn(\"edit\");'><span class='fas fa-pencil-alt'></span>" + this.strings.editButton + "</div>" +
                     "<div rel='best-answer' class='item' onclick='quickAlgoInterface.editorBtn(\"best-answer\");'><span class='fas fa-trophy'></span> " + this.strings.loadBestAnswer + "</div>" +
                     "<div rel='blockly-python' class='item' onclick='quickAlgoInterface.editorBtn(\"blockly-python\");'><span class='fas fa-file-code'></span> " + this.strings.blocklyToPython + "</div>" +
                 "</div>" +
@@ -249,27 +250,74 @@ var quickAlgoInterface = {
     editorBtn: function(btn) {
         // Handle an editor button press
         this.closeEditorMenu();
-        if(btn == 'example') {
+        if (btn == 'example') {
             task.displayedSubTask.loadExample()
-        } else if(btn == 'copy') {
+        } else if (btn == 'copy') {
             task.displayedSubTask.blocklyHelper.copyProgram();
-        } else if(btn == 'paste') {
+        } else if (btn == 'paste') {
             task.displayedSubTask.blocklyHelper.pasteProgram();
-        } else if(btn == 'save') {
+        } else if (btn == 'save') {
             task.displayedSubTask.blocklyHelper.saveProgram();
-        } else if(btn == 'restart') {
+        } else if (btn == 'restart') {
             displayHelper.restartAll();
-        } else if(btn == 'best-answer') {
+        } else if (btn == 'edit') {
+            this.openEditExercise();
+        } else if (btn == 'best-answer') {
             displayHelper.retrieveAnswer();
-        } else if(btn == 'blockly-python') {
+        } else if (btn == 'blockly-python') {
             this.displayBlocklyPython();
         }
+    },
+
+    openEditExercise: function() {
+        var description = $(".exerciseText");
+        var editExerciseHtml = "<div class=\"content connectPi qpi\">" +
+            "    <div class=\"panel-heading\">" +
+            "        <h2 class=\"sectionTitle\">" +
+            "            <span class=\"iconTag\"><i class=\"icon fas fa-pencil-alt\"></i></span>" +
+            "            ${this.strings.editWindowTitle}" +
+            "        </h2>" +
+            "    <div class=\"exit\" id=\"editclose\"><i class=\"icon fas fa-times\"></i></div>" +
+            "    </div>" +
+            "    <div class=\"panel-body\">" +
+            "        <div id=\"editExerciseTitle\">" +
+            "            <label>${this.strings.titleEdition} </label><input id=\"editExerciseTitleInput\" type=\"text\" value=\"${document.title}\"/>" +
+            "        </div>" +
+            "        <div id=\"editExerciseDescription\">" +
+            "            <label>${this.strings.descriptionEdition}</label>" +
+            "            <textarea rows=\"10\" id=\"editExerciseDescriptionTextarea\">${description}</textarea>" +
+            "        </div>" +
+            "    </div>" +
+            "</div>";
+
+        window.displayHelper.showPopupDialog(editExerciseHtml);
+
+        $("#editclose").click(function() {
+            $('#popupMessage').hide();
+            window.displayHelper.popupMessageShown = false;
+            var newTitle = $("#editExerciseTitleInput").val();
+            var newDesc = $("#editExerciseDescriptionTextarea").val();
+
+            document.title = newTitle;
+            $(".exerciseText").text(newDesc);
+        });
     },
 
     loadPrograms: function(formElement) {
         this.blocklyHelper.handleFiles(formElement.files);
         resetFormElement($(formElement));
         this.closeEditorMenu();
+    },
+
+    /**
+     * This function allow us to save the subject into the additional data saved inside of the interface
+     * @param additional The additional data where we should save subject
+     */
+    saveSubject: function(additional) {
+        additional.subject = {
+            title: document.title,
+            description: $(".exerciseText").text()
+        };
     },
 
     setOptions: function(opt) {
@@ -299,6 +347,7 @@ var quickAlgoInterface = {
         $('#editorMenu div[rel=restart]').toggleClass('interfaceToggled', !!hideControls.restart);
         $('#editorMenu div[rel=save]').toggleClass('interfaceToggled', !!hideControls.saveOrLoad);
         $('#editorMenu div[rel=load]').toggleClass('interfaceToggled', !!hideControls.saveOrLoad);
+        $('#editorMenu div[rel=edit]').toggleClass('interfaceToggled', !this.options.canEditSubject); // HERE
         $('#editorMenu div[rel=best-answer]').toggleClass('interfaceToggled', !!hideControls.loadBestAnswer);
         $('#editorMenu div[rel=blockly-python]').toggleClass('interfaceToggled', hideControls.blocklyToPython !== false || !this.blocklyHelper || !this.blocklyHelper.isBlockly);
 

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -128,15 +128,15 @@ var quickAlgoInterface = {
         this.strings = window.languageStrings;
         this.level = level;
 
-        // if we setup the userTaskData from subtask (the file task.js) then
-        // we must load the subject
+        // if we don't have userTaskData loaded, then we load it from the subject
         if (!this.userTaskData) {
-            // wrost case: we don't have a subject, then we load our userTaskData from the subject
-            this.userTaskData.title = document.title;
-            this.userTaskData.subject = $(".exerciseText").first().text();
+            this.userTaskData = {
+                title: document.title,
+                subject: $(".exerciseText").first().text()
+            };
+        } else {
+            this.loadSubjectFromUserTaskData();
         }
-
-        this.loadSubjectFromUserTaskData();
 
         var gridHtml = "";
         gridHtml += "<div id='gridButtonsBefore'></div>";

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -270,22 +270,25 @@ var quickAlgoInterface = {
     },
 
     openEditExercise: function() {
-        var description = $(".exerciseText");
+        // in python, there are two "exerciseText", we need to selected only the first one
+        // there are two "exerciseText" in python, because we also have a "long" version of the
+        // subject
+        var description = $(".exerciseText").first().text();
         var editExerciseHtml = "<div class=\"content connectPi qpi\">" +
             "    <div class=\"panel-heading\">" +
             "        <h2 class=\"sectionTitle\">" +
             "            <span class=\"iconTag\"><i class=\"icon fas fa-pencil-alt\"></i></span>" +
-            "            ${this.strings.editWindowTitle}" +
+                         this.strings.editWindowTitle +
             "        </h2>" +
             "    <div class=\"exit\" id=\"editclose\"><i class=\"icon fas fa-times\"></i></div>" +
             "    </div>" +
             "    <div class=\"panel-body\">" +
             "        <div id=\"editExerciseTitle\">" +
-            "            <label>${this.strings.titleEdition} </label><input id=\"editExerciseTitleInput\" type=\"text\" value=\"${document.title}\"/>" +
+            "            <label>" + this.strings.titleEdition + "</label><input id=\"editExerciseTitleInput\" type=\"text\" value=\"" + document.title + "\"/>" +
             "        </div>" +
             "        <div id=\"editExerciseDescription\">" +
-            "            <label>${this.strings.descriptionEdition}</label>" +
-            "            <textarea rows=\"10\" id=\"editExerciseDescriptionTextarea\">${description}</textarea>" +
+            "            <label>" + this.strings.descriptionEdition + "</label>" +
+            "            <textarea rows=\"10\" id=\"editExerciseDescriptionTextarea\">" + description + "</textarea>" +
             "        </div>" +
             "    </div>" +
             "</div>";
@@ -311,13 +314,37 @@ var quickAlgoInterface = {
 
     /**
      * This function allow us to save the subject into the additional data saved inside of the interface
+     * This also save the element from the context
      * @param additional The additional data where we should save subject
      */
     saveSubject: function(additional) {
-        additional.subject = {
-            title: document.title,
-            description: $(".exerciseText").text()
-        };
+        if (this.options.canEditSubject) {
+            additional.subject = {
+                title: document.title,
+                subject: $(".exerciseText").first().text()
+            };
+        }
+        // save additional from context too
+        if (this.context.saveAdditional) {
+            this.context.saveAdditional(additional);
+            // TODO: check if we can modify sensors, otherwise we don't save them
+        }
+    },
+
+    /**
+     * This function allow us to load the additional things for the exercise like subject/sensors for quickpi
+     * @param additional The additional object containing additional things to load
+     */
+    loadAdditional: function(additional) {
+        // load subject if edition is enabled
+        if (additional.subject && this.options.canEditSubject) {
+            document.title = additional.subject.title;
+            $(".exerciseText").text(additional.subject.subject);
+        }
+        // Load additional from context (sensors for quickpi for example)
+        if (this.context.loadAdditional) {
+            this.context.loadAdditional(additional);
+        }
     },
 
     setOptions: function(opt) {
@@ -347,7 +374,7 @@ var quickAlgoInterface = {
         $('#editorMenu div[rel=restart]').toggleClass('interfaceToggled', !!hideControls.restart);
         $('#editorMenu div[rel=save]').toggleClass('interfaceToggled', !!hideControls.saveOrLoad);
         $('#editorMenu div[rel=load]').toggleClass('interfaceToggled', !!hideControls.saveOrLoad);
-        $('#editorMenu div[rel=edit]').toggleClass('interfaceToggled', !this.options.canEditSubject); // HERE
+        $('#editorMenu div[rel=edit]').toggleClass('interfaceToggled', !this.options.canEditSubject);
         $('#editorMenu div[rel=best-answer]').toggleClass('interfaceToggled', !!hideControls.loadBestAnswer);
         $('#editorMenu div[rel=blockly-python]').toggleClass('interfaceToggled', hideControls.blocklyToPython !== false || !this.blocklyHelper || !this.blocklyHelper.isBlockly);
 

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -290,14 +290,35 @@ var quickAlgoInterface = {
             "            <label>" + this.strings.descriptionEdition + "</label>" +
             "            <textarea rows=\"10\" id=\"editExerciseDescriptionTextarea\">" + description + "</textarea>" +
             "        </div>" +
+            "        <div id='panel-body-bottom'>" +
+            "            <button id='saveExerciseChanges'>" + this.strings.saveAndQuit + "</button>" +
+            "        </div>" +
             "    </div>" +
             "</div>";
 
         window.displayHelper.showPopupDialog(editExerciseHtml);
 
+        var that = this;
+
         $("#editclose").click(function() {
+            var newTitle = $("#editExerciseTitleInput").val();
+            var newDesc = $("#editExerciseDescriptionTextarea").val();
+            var oldTitle = document.title;
+            var oldDescription = $(".exerciseText").first().text();
+            if (newTitle !== oldTitle || newDesc !== oldDescription) {
+                if (!window.confirm(that.strings.quitWithoutSavingConfirmation)) {
+                    return;
+                }
+            }
+
             $('#popupMessage').hide();
             window.displayHelper.popupMessageShown = false;
+        });
+
+        $("#saveExerciseChanges").click(function() {
+            $('#popupMessage').hide();
+            window.displayHelper.popupMessageShown = false;
+
             var newTitle = $("#editExerciseTitleInput").val();
             var newDesc = $("#editExerciseDescriptionTextarea").val();
 

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -340,7 +340,7 @@ var quickAlgoInterface = {
      */
     saveSubject: function(additional) {
         if (this.options.canEditSubject) {
-            additional.subject = {
+            additional.userTaskData = {
                 title: document.title,
                 subject: $(".exerciseText").first().text()
             };
@@ -357,9 +357,9 @@ var quickAlgoInterface = {
      */
     loadAdditional: function(additional) {
         // load subject if edition is enabled
-        if (additional.subject && this.options.canEditSubject) {
-            document.title = additional.subject.title;
-            $(".exerciseText").text(additional.subject.subject);
+        if (additional.userTaskData && this.options.canEditSubject) {
+            document.title = additional.userTaskData.title;
+            $(".exerciseText").text(additional.userTaskData.subject);
         }
         // Load additional from context (sensors for quickpi for example)
         if (this.context.loadAdditional) {

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -348,7 +348,6 @@ var quickAlgoInterface = {
         // save additional from context too
         if (this.context.saveAdditional) {
             this.context.saveAdditional(additional);
-            // TODO: check if we can modify sensors, otherwise we don't save them
         }
     },
 

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -325,8 +325,8 @@ var quickAlgoInterface = {
         $("#editclose").click(function() {
             var newTitle = $("#editExerciseTitleInput").val();
             var newDesc = $("#editExerciseDescriptionTextarea").val();
-            var oldTitle = document.title;
-            var oldDescription = $(".exerciseText").first().text();
+            var oldTitle = that.userTaskData.title;
+            var oldDescription = that.userTaskData.subject;
             if (newTitle !== oldTitle || newDesc !== oldDescription) {
                 if (!window.confirm(that.strings.quitWithoutSavingConfirmation)) {
                     return;

--- a/pemFioi/quickAlgo/python_interface.js
+++ b/pemFioi/quickAlgo/python_interface.js
@@ -41,8 +41,8 @@ function LogicController(nbTestCases, maxInstructions) {
       this.programs[0].blockly = this._aceEditor.getValue();
       if (full) {
         var additional = {};
-        if (window.quickAlgoInterface && window.quickAlgoInterface.saveSubject)
-          window.quickAlgoInterface.saveSubject(additional);
+        if (window.quickAlgoInterface && window.quickAlgoInterface.saveAdditional)
+          window.quickAlgoInterface.saveAdditional(additional);
         this.programs[0].additional = additional;
       }
     }

--- a/pemFioi/quickAlgo/python_interface.js
+++ b/pemFioi/quickAlgo/python_interface.js
@@ -41,7 +41,8 @@ function LogicController(nbTestCases, maxInstructions) {
       this.programs[0].blockly = this._aceEditor.getValue();
       if (full) {
         var additional = {};
-        this._mainContext.saveAdditional(additional);
+        if (window.quickAlgoInterface && window.quickAlgoInterface.saveSubject)
+          window.quickAlgoInterface.saveSubject(additional);
         this.programs[0].additional = additional;
       }
     }
@@ -53,7 +54,8 @@ function LogicController(nbTestCases, maxInstructions) {
       this._aceEditor.selection.clearSelection();
     }
     if (this._aceEditor && this.programs[0].additional) {
-      this._mainContext.loadAdditional(this.programs[0].additional);
+      if (window.quickAlgoInterface && window.quickAlgoInterface.loadAdditional)
+        window.quickAlgoInterface.loadAdditional(this.programs[0].additional);
     }
   };
 

--- a/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
+++ b/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
@@ -1872,3 +1872,23 @@ button.showLongIntro .icon {
 .panel-heading.panel-heading-nopadding {
     padding: 0px;
 }
+#editExerciseTitle {
+  display: flex;
+  justify-content: space-between;
+  margin-right: 44px;
+}
+#editExerciseTitle label {
+  font-size: 12px;
+}
+#editExerciseTitle input {
+  width: 90%;
+}
+#editExerciseDescription label {
+  font-size: 12px;
+}
+#editExerciseDescription textarea {
+  width: 100%;
+  height: 100%;
+  resize: vertical;
+  margin-right: 44px;
+}

--- a/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
+++ b/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
@@ -1892,3 +1892,8 @@ button.showLongIntro .icon {
   resize: vertical;
   margin-right: 44px;
 }
+#panel-body-bottom {
+  padding-top: 8px;
+  display: flex;
+  justify-content: right;
+}

--- a/pemFioi/quickAlgo/subtask.js
+++ b/pemFioi/quickAlgo/subtask.js
@@ -69,6 +69,8 @@ var initBlocklySubTask = function(subTask, language) {
       this.context.blocklyHelper = this.blocklyHelper;
 
       if (this.display) {
+         if (window.quickAlgoInterface.loadUserTaskData)
+            window.quickAlgoInterface.loadUserTaskData(levelGridInfos.userTaskData);
          window.quickAlgoInterface.loadInterface(this.context, curLevel);
          window.quickAlgoInterface.setOptions({
             hasExample: levelGridInfos.example && levelGridInfos.example[subTask.blocklyHelper.language],

--- a/pemFioi/quickAlgo/subtask.js
+++ b/pemFioi/quickAlgo/subtask.js
@@ -76,7 +76,8 @@ var initBlocklySubTask = function(subTask, language) {
             conceptViewerLang: this.blocklyHelper.language,
             hasTestThumbnails: levelGridInfos.hasTestThumbnails,
             hideControls: levelGridInfos.hideControls,
-            introMaxHeight: levelGridInfos.introMaxHeight
+            introMaxHeight: levelGridInfos.introMaxHeight,
+            canEditSubject: !!levelGridInfos.canEditSubject
          });
          window.quickAlgoInterface.bindBlocklyHelper(this.blocklyHelper);
       }

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -3292,6 +3292,9 @@ var getContext = function (display, infos, curLevel) {
      */
     context.loadAdditional = function(additional) {
         var newSensors = additional.quickpiSensors;
+
+        // we don't verify if sensors are empty or not, because if they are it is maybe meant this
+        // way by the user
         if (!newSensors)
             return;
 

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -3263,7 +3263,7 @@ var getContext = function (display, infos, curLevel) {
     context.board = "quickpi";
 
     if (getSessionStorage('board'))
-        context.changeBoard(getSessionStorage('board'))
+        context.changeBoard(getSessionStorage('board'));
 
     /**
      * This method allow us to save the sensors inside of the variable additional.
@@ -3271,6 +3271,10 @@ var getContext = function (display, infos, curLevel) {
      * @param additional The additional object saved inside of the xml
      */
     context.saveAdditional = function(additional) {
+        // we don't need to save sensors if user can't modify them
+        if (!infos.customSensors)
+            return;
+
         additional.quickpiSensors = [];
         for (var i = 0; i < infos.quickPiSensors.length; i++) {
             var currentSensor = infos.quickPiSensors[i];
@@ -3291,6 +3295,10 @@ var getContext = function (display, infos, curLevel) {
      * @param additional The additional variable which contains the sensors
      */
     context.loadAdditional = function(additional) {
+        // we load sensors only if custom sensors is available
+        if (!infos.customSensors)
+            return;
+
         var newSensors = additional.quickpiSensors;
 
         // we don't verify if sensors are empty or not, because if they are it is maybe meant this

--- a/pemFioi/taskStyles-mobileFirst.css
+++ b/pemFioi/taskStyles-mobileFirst.css
@@ -411,6 +411,7 @@ img {
   left: 50%;
   top: 0;
   transform: translate(-50%, 0);
+}
 #popupMessage .qpi #sensorPicker #selector-label {
   position: absolute;
   top: 15px;


### PR DESCRIPTION
Recreated the edit_exercise pull request ([#68 ](https://github.com/France-ioi/bebras-modules/pull/68)), but now, the sensors are saved in json inside of the "additional" field of the subject.

I also have changed the sensors saving: if user can't edit the sensors, then the sensors are not saved nor loaded if user load a file containing custom sensors.

Now it is quickAlgoInterface which is in charge of saving the aditional:
The call to function from quickPi to save the sensors in blockly and quickpi has been moved into a function that also save the subject.

I also have added a button to save the edition of the exercice, clicking on the "x", cancel changes and close the menu but the "save & quit" button save the changes before exit. When user click on "x", and he has done some changes to the subject, then it ask for user confirmation for cancelling changes.