### PR TITLE
Add about to QuickAlgo

### DIFF
--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -75,6 +75,9 @@ var quickAlgoLanguageStrings = {
       about: "À propos",
       license: "license :",
       authors: "Auteurs :",
+      other: "Autre",
+      otherLicense: "Autre license",
+      pleaseSpecifyLicense: "Merci de spécifier une license",
       avoidReloadingOtherTask: "Attention : ne rechargez pas le programme d'un autre sujet !",
       files: "Fichiers",
       reloadProgram: "Recharger",
@@ -211,6 +214,10 @@ var quickAlgoLanguageStrings = {
       quitWithoutSavingConfirmation: "Quit without saving your modifications ?",
       about: "About",
       license: "license:",
+      authors: "Authors:",
+      other: "Other",
+      otherLicense: "Other license",
+      pleaseSpecifyLicense: "Please specify a license",
       avoidReloadingOtherTask: "Warning: do not reload code for another task!",
       files: "Files",
       reloadProgram: "Reload",
@@ -349,6 +356,9 @@ var quickAlgoLanguageStrings = {
       about: "À propos", // TODO: translate
       license: "lizenz:", // TODO: verify
       authors: "Autoren :", // TODO: verify
+      other: "Andere", // TODO: verify
+      otherLicense: "Other license", // TODO: translate
+      pleaseSpecifyLicense: "Merci de spécifier une license", // TODO: translate
       avoidReloadingOtherTask: "Warnung: Lade keinen Quelltext von einer anderen Aufgabe!",
       files: "Dateien",
       reloadProgram: "Laden",
@@ -487,7 +497,10 @@ var quickAlgoLanguageStrings = {
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       about: "À propos", // TODO: translate
       license: "licencia:", // TODO: verify
-      authors: "autores:", // TODO: verify
+      authors: "Autores:", // TODO: verify
+      other: "Otro", // TODO: verify
+      otherLicense: "Other license", // TODO: translate
+      pleaseSpecifyLicense: "Merci de spécifier une license", // TODO: translate
       avoidReloadingOtherTask: "Atención: ¡no recargue el programa de otro problema!",
       files: "Archivos",
       reloadProgram: "Recargar",
@@ -624,7 +637,10 @@ var quickAlgoLanguageStrings = {
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       about: "À propos", // TODO: Translate
       license: "licenca:", // TODO: tanslate
-      authors: "avtorji:", // TODO: translate
+      authors: "Avtorji:", // TODO: translate
+      other: "drugo", // TODO: verify
+      otherLicense: "Other license", // TODO: translate
+      pleaseSpecifyLicense: "Merci de spécifier une license", // TODO: translate
       avoidReloadingOtherTask: "Opozorilo: Za drugo nalogo ne naloži kode znova!",
       files: "Datoteke",
       reloadProgram: "Znova naloži",
@@ -764,6 +780,9 @@ var quickAlgoLanguageStrings = {
       about: "À propos", // TODO: Translate
       license: "licenza:", // TODO: verify
       authors: "autori:", // TODO: verify
+      other: "Altro", // TODO: verify
+      otherLicense: "Other license", // TODO: translate
+      pleaseSpecifyLicense: "Merci de spécifier une license", // TODO: translate
       avoidReloadingOtherTask: "Attenzione: non ricaricare il programma di un altro argomento!",
       files: "File",
       reloadProgram: "Ricarica",

--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -32,7 +32,7 @@ var quickAlgoLanguageStrings = {
       exerciseTypeAbout: {
          default: "Sujet propulsé par <a href='http://www.france-ioi.org/'>France-IOI</a>",
          "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> " +
-             "est un projet par <a href='http://www.france-ioi.org/'>France-IOI</a>"
+             "est un projet de <a href='http://www.france-ioi.org/'>France-IOI</a>"
       },
       invalidContent: "Contenu invalide",
       unknownFileType: "Type de fichier non reconnu",
@@ -73,6 +73,8 @@ var quickAlgoLanguageStrings = {
       saveAndQuit: "Sauvegarder & Quitter",
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?",
       about: "À propos",
+      license: "license :",
+      authors: "Auteurs :",
       avoidReloadingOtherTask: "Attention : ne rechargez pas le programme d'un autre sujet !",
       files: "Fichiers",
       reloadProgram: "Recharger",
@@ -207,7 +209,8 @@ var quickAlgoLanguageStrings = {
       descriptionEdition: "Description:",
       saveAndQuit: "Save & Quit",
       quitWithoutSavingConfirmation: "Quit without saving your modifications ?",
-      about: "À propos", // TODO: translate
+      about: "About",
+      license: "license:",
       avoidReloadingOtherTask: "Warning: do not reload code for another task!",
       files: "Files",
       reloadProgram: "Reload",
@@ -344,6 +347,8 @@ var quickAlgoLanguageStrings = {
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       about: "À propos", // TODO: translate
+      license: "lizenz:", // TODO: verify
+      authors: "Autoren :", // TODO: verify
       avoidReloadingOtherTask: "Warnung: Lade keinen Quelltext von einer anderen Aufgabe!",
       files: "Dateien",
       reloadProgram: "Laden",
@@ -481,6 +486,8 @@ var quickAlgoLanguageStrings = {
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       about: "À propos", // TODO: translate
+      license: "licencia:", // TODO: verify
+      authors: "autores:", // TODO: verify
       avoidReloadingOtherTask: "Atención: ¡no recargue el programa de otro problema!",
       files: "Archivos",
       reloadProgram: "Recargar",
@@ -616,6 +623,8 @@ var quickAlgoLanguageStrings = {
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       about: "À propos", // TODO: Translate
+      license: "licenca:", // TODO: tanslate
+      authors: "avtorji:", // TODO: translate
       avoidReloadingOtherTask: "Opozorilo: Za drugo nalogo ne naloži kode znova!",
       files: "Datoteke",
       reloadProgram: "Znova naloži",
@@ -753,6 +762,8 @@ var quickAlgoLanguageStrings = {
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       about: "À propos", // TODO: Translate
+      license: "licenza:", // TODO: verify
+      authors: "autori:", // TODO: verify
       avoidReloadingOtherTask: "Attenzione: non ricaricare il programma di un altro argomento!",
       files: "File",
       reloadProgram: "Ricarica",

--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -170,7 +170,7 @@ var quickAlgoLanguageStrings = {
          print: "Writing",
       },
       exerciseTypeAbout: {
-         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>",
+         default: "Task powered by <a href='http://www.france-ioi.org/'>France-IOI</a>",
          "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
              "<a href='http://www.france-ioi.org/'>France-IOI</a>"
       },
@@ -311,7 +311,7 @@ var quickAlgoLanguageStrings = {
          manipulate: "Umwandeln",
       },
       exerciseTypeAbout: {
-         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
+         default: "Task powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
          "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
              "<a href='http://www.france-ioi.org/'>France-IOI</a>" // TODO: translate
       },
@@ -453,7 +453,7 @@ var quickAlgoLanguageStrings = {
          display: "Pantalla",
       },
       exerciseTypeAbout: {
-         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
+         default: "Task powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
          "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
              "<a href='http://www.france-ioi.org/'>France-IOI</a>" // TODO: translate
       },
@@ -593,7 +593,7 @@ var quickAlgoLanguageStrings = {
          turtle: "Želva"
       },
       exerciseTypeAbout: {
-         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
+         default: "Task powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
          "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
              "<a href='http://www.france-ioi.org/'>France-IOI</a>" // TODO: translate
       },
@@ -735,7 +735,7 @@ var quickAlgoLanguageStrings = {
          display: "Mostra",
       },
       exerciseTypeAbout: {
-         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
+         default: "Task powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
          "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
              "<a href='http://www.france-ioi.org/'>France-IOI</a>" // TODO: translate
       },

--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -779,7 +779,7 @@ var quickAlgoLanguageStrings = {
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       about: "À propos", // TODO: Translate
       license: "Licenza:", // TODO: verify
-      authors: "autori:", // TODO: verify
+      authors: "Autori:", // TODO: verify
       other: "Altro", // TODO: verify
       otherLicense: "Other license", // TODO: translate
       pleaseSpecifyLicense: "Merci de spécifier une license", // TODO: translate

--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -29,6 +29,11 @@ var quickAlgoLanguageStrings = {
          internet: "Internet",
          display: "Afficher",
       },
+      exerciseTypeAbout: {
+         default: "Sujet propulsé par <a href='http://www.france-ioi.org/'>France-IOI</a>",
+         "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> " +
+             "est un projet par <a href='http://www.france-ioi.org/'>France-IOI</a>"
+      },
       invalidContent: "Contenu invalide",
       unknownFileType: "Type de fichier non reconnu",
       download: "télécharger",
@@ -158,6 +163,11 @@ var quickAlgoLanguageStrings = {
          functions: "Functions",
          read: "Reading",
          print: "Writing",
+      },
+      exerciseTypeAbout: {
+         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>",
+         "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
+             "<a href='http://www.france-ioi.org/'>France-IOI</a>"
       },
       invalidContent: "Invalid content",
       unknownFileType: "Unrecognized file type",
@@ -289,6 +299,11 @@ var quickAlgoLanguageStrings = {
          read: "Einlesen",
          print: "Ausgeben",
          manipulate: "Umwandeln",
+      },
+      exerciseTypeAbout: {
+         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>",
+         "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
+             "<a href='http://www.france-ioi.org/'>France-IOI</a>"
       },
       invalidContent: "Ungültiger Inhalt",
       unknownFileType: "Ungültiger Datentyp",
@@ -422,6 +437,11 @@ var quickAlgoLanguageStrings = {
          internet: "Internet",
          display: "Pantalla",
       },
+      exerciseTypeAbout: {
+         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>",
+         "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
+             "<a href='http://www.france-ioi.org/'>France-IOI</a>"
+      },
       invalidContent: "Contenido inválido",
       unknownFileType: "Tipo de archivo no reconocido",
       download: "descargar",
@@ -551,6 +571,11 @@ var quickAlgoLanguageStrings = {
          read: "Branje",
          print: "Pisanje",
          turtle: "Želva"
+      },
+      exerciseTypeAbout: {
+         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>",
+         "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
+             "<a href='http://www.france-ioi.org/'>France-IOI</a>"
       },
       invalidContent: "Neveljavna vsebina",
       unknownFileType: "Neznana vrsta datoteke",
@@ -683,6 +708,11 @@ var quickAlgoLanguageStrings = {
          print: "Stampa",
          internet: "Internet",
          display: "Mostra",
+      },
+      exerciseTypeAbout: {
+         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>",
+         "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
+             "<a href='http://www.france-ioi.org/'>France-IOI</a>"
       },
       invalidContent: "Contenuto non valido",
       unknownFileType: "Tipo di file non riconosciuto",

--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -311,9 +311,9 @@ var quickAlgoLanguageStrings = {
          manipulate: "Umwandeln",
       },
       exerciseTypeAbout: {
-         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>",
+         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
          "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
-             "<a href='http://www.france-ioi.org/'>France-IOI</a>"
+             "<a href='http://www.france-ioi.org/'>France-IOI</a>" // TODO: translate
       },
       invalidContent: "Ungültiger Inhalt",
       unknownFileType: "Ungültiger Datentyp",
@@ -453,9 +453,9 @@ var quickAlgoLanguageStrings = {
          display: "Pantalla",
       },
       exerciseTypeAbout: {
-         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>",
+         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
          "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
-             "<a href='http://www.france-ioi.org/'>France-IOI</a>"
+             "<a href='http://www.france-ioi.org/'>France-IOI</a>" // TODO: translate
       },
       invalidContent: "Contenido inválido",
       unknownFileType: "Tipo de archivo no reconocido",
@@ -593,9 +593,9 @@ var quickAlgoLanguageStrings = {
          turtle: "Želva"
       },
       exerciseTypeAbout: {
-         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>",
+         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
          "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
-             "<a href='http://www.france-ioi.org/'>France-IOI</a>"
+             "<a href='http://www.france-ioi.org/'>France-IOI</a>" // TODO: translate
       },
       invalidContent: "Neveljavna vsebina",
       unknownFileType: "Neznana vrsta datoteke",
@@ -735,9 +735,9 @@ var quickAlgoLanguageStrings = {
          display: "Mostra",
       },
       exerciseTypeAbout: {
-         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>",
+         default: "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>", // TODO: translate
          "Quick-Pi": "<a href='https://quick-pi.org/'>Quick-Pi</a> is a project by " +
-             "<a href='http://www.france-ioi.org/'>France-IOI</a>"
+             "<a href='http://www.france-ioi.org/'>France-IOI</a>" // TODO: translate
       },
       invalidContent: "Contenuto non valido",
       unknownFileType: "Tipo di file non riconosciuto",

--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -67,6 +67,7 @@ var quickAlgoLanguageStrings = {
       descriptionEdition: "Description :",
       saveAndQuit: "Sauvegarder & Quitter",
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?",
+      about: "À propos",
       avoidReloadingOtherTask: "Attention : ne rechargez pas le programme d'un autre sujet !",
       files: "Fichiers",
       reloadProgram: "Recharger",
@@ -196,6 +197,7 @@ var quickAlgoLanguageStrings = {
       descriptionEdition: "Description:",
       saveAndQuit: "Save & Quit",
       quitWithoutSavingConfirmation: "Quit without saving your modifications ?",
+      about: "À propos", // TODO: translate
       avoidReloadingOtherTask: "Warning: do not reload code for another task!",
       files: "Files",
       reloadProgram: "Reload",
@@ -326,6 +328,7 @@ var quickAlgoLanguageStrings = {
       descriptionEdition: "Beschreibung:", // TODO: verify
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
+      about: "À propos", // TODO: translate
       avoidReloadingOtherTask: "Warnung: Lade keinen Quelltext von einer anderen Aufgabe!",
       files: "Dateien",
       reloadProgram: "Laden",
@@ -457,6 +460,7 @@ var quickAlgoLanguageStrings = {
       descriptionEdition: "Descripción:", // TODO: verify
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
+      about: "À propos", // TODO: translate
       avoidReloadingOtherTask: "Atención: ¡no recargue el programa de otro problema!",
       files: "Archivos",
       reloadProgram: "Recargar",
@@ -586,6 +590,7 @@ var quickAlgoLanguageStrings = {
       descriptionEdition: "Opis:", // TODO: verify
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
+      about: "À propos", // TODO: Translate
       avoidReloadingOtherTask: "Opozorilo: Za drugo nalogo ne naloži kode znova!",
       files: "Datoteke",
       reloadProgram: "Znova naloži",
@@ -717,6 +722,7 @@ var quickAlgoLanguageStrings = {
       descriptionEdition: "Descrizione:", // TODO: verify
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
+      about: "À propos", // TODO: Translate
       avoidReloadingOtherTask: "Attenzione: non ricaricare il programma di un altro argomento!",
       files: "File",
       reloadProgram: "Ricarica",

--- a/pemFioi/quickAlgo/i18n.js
+++ b/pemFioi/quickAlgo/i18n.js
@@ -73,7 +73,7 @@ var quickAlgoLanguageStrings = {
       saveAndQuit: "Sauvegarder & Quitter",
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?",
       about: "À propos",
-      license: "license :",
+      license: "License :",
       authors: "Auteurs :",
       other: "Autre",
       otherLicense: "Autre license",
@@ -213,7 +213,7 @@ var quickAlgoLanguageStrings = {
       saveAndQuit: "Save & Quit",
       quitWithoutSavingConfirmation: "Quit without saving your modifications ?",
       about: "About",
-      license: "license:",
+      license: "License:",
       authors: "Authors:",
       other: "Other",
       otherLicense: "Other license",
@@ -354,7 +354,7 @@ var quickAlgoLanguageStrings = {
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       about: "À propos", // TODO: translate
-      license: "lizenz:", // TODO: verify
+      license: "Lizenz:", // TODO: verify
       authors: "Autoren :", // TODO: verify
       other: "Andere", // TODO: verify
       otherLicense: "Other license", // TODO: translate
@@ -496,7 +496,7 @@ var quickAlgoLanguageStrings = {
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       about: "À propos", // TODO: translate
-      license: "licencia:", // TODO: verify
+      license: "Licencia:", // TODO: verify
       authors: "Autores:", // TODO: verify
       other: "Otro", // TODO: verify
       otherLicense: "Other license", // TODO: translate
@@ -636,7 +636,7 @@ var quickAlgoLanguageStrings = {
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       about: "À propos", // TODO: Translate
-      license: "licenca:", // TODO: tanslate
+      license: "Licenca:", // TODO: tanslate
       authors: "Avtorji:", // TODO: translate
       other: "drugo", // TODO: verify
       otherLicense: "Other license", // TODO: translate
@@ -778,7 +778,7 @@ var quickAlgoLanguageStrings = {
       saveAndQuit: "Sauvegarder & Quitter", // TODO: translate
       quitWithoutSavingConfirmation: "Quitter sans sauvegarder vos modifications ?", // TODO: translate
       about: "À propos", // TODO: Translate
-      license: "licenza:", // TODO: verify
+      license: "Licenza:", // TODO: verify
       authors: "autori:", // TODO: verify
       other: "Altro", // TODO: verify
       otherLicense: "Other license", // TODO: translate

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -250,9 +250,9 @@ var quickAlgoInterface = {
                         this.strings.reloadProgram +
                     "</div>" +
                     "<div rel='edit' class='item' onclick='quickAlgoInterface.editorBtn(\"edit\");'><span class='fas fa-pencil-alt'></span>" + this.strings.editButton + "</div>" +
-                    "<div rel='about' class='item' onclick='quickAlgoInterface.editorBtn(\"about\");'><span class='fas fa-question-circle'></span>" + this.strings.about + "</div>" +
                     "<div rel='best-answer' class='item' onclick='quickAlgoInterface.editorBtn(\"best-answer\");'><span class='fas fa-trophy'></span> " + this.strings.loadBestAnswer + "</div>" +
                     "<div rel='blockly-python' class='item' onclick='quickAlgoInterface.editorBtn(\"blockly-python\");'><span class='fas fa-file-code'></span> " + this.strings.blocklyToPython + "</div>" +
+                    "<div rel='about' class='item' onclick='quickAlgoInterface.editorBtn(\"about\");'><span class='fas fa-question-circle'></span>" + this.strings.about + "</div>" +
                 "</div>" +
                 "<span id='saveUrl'></span>" +
             "</div>"
@@ -296,12 +296,12 @@ var quickAlgoInterface = {
             displayHelper.restartAll();
         } else if (btn == 'edit') {
             this.openEditExercise();
-        } else if (btn == 'about') {
-            this.openAbout();
         } else if (btn == 'best-answer') {
             displayHelper.retrieveAnswer();
         } else if (btn == 'blockly-python') {
             this.displayBlocklyPython();
+        } else if (btn == 'about') {
+            this.openAbout();
         }
     },
 
@@ -643,9 +643,9 @@ var quickAlgoInterface = {
         $('#editorMenu div[rel=restart]').toggleClass('interfaceToggled', !!hideControls.restart);
         $('#editorMenu div[rel=save]').toggleClass('interfaceToggled', !!hideControls.saveOrLoad);
         $('#editorMenu div[rel=load]').toggleClass('interfaceToggled', !!hideControls.saveOrLoad);
-        $('#editorMenu div[rel=edit]').toggleClass('interfaceToggled', !this.options.canEditSubject);
         $('#editorMenu div[rel=best-answer]').toggleClass('interfaceToggled', !!hideControls.loadBestAnswer);
         $('#editorMenu div[rel=blockly-python]').toggleClass('interfaceToggled', hideControls.blocklyToPython !== false || !this.blocklyHelper || !this.blocklyHelper.isBlockly);
+        $('#editorMenu div[rel=edit]').toggleClass('interfaceToggled', !this.options.canEditSubject);
 
         var menuHidden = !this.options.hasExample && hideControls.restart && hideControls.saveOrLoad && hideControls.loadBestAnswer;
         $('#openEditorMenu').toggleClass('interfaceToggled', !!menuHidden);

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -410,10 +410,33 @@ var quickAlgoInterface = {
         });
     },
 
+    _getAboutLicenseButton: function(license) {
+
+    },
+
     openAbout: function() {
+        var that = this;
+
         var authors = this.userTaskData.about.authors;
 
         var license = this.userTaskData.about.license;
+
+        /**
+         * This function return the button hidden or not depending on the boolean in argument.
+         * This function can also be called without arguments and the button will not be hidden.
+         *
+         * The button is hidden in case we have not a license that we know about.
+         * @param hidden If the button should be hidden or not (or no argument in this case the button is shown)
+         * @return {string}  The html for the button
+         */
+        function getAboutLicenseButton(hidden) {
+            if (!hidden)
+                hidden = "";
+            else
+                hidden = "style='display: none;'";
+            return "<span id='aboutLicenseIcon' class='icon fas fa-question-circle' onclick='window.open(\""
+                + that.licenses[license] + "\", \"_blank\");' " + hidden + "></span>";
+        }
 
         var aboutAuthorsLicenseSection = null;
 
@@ -423,8 +446,7 @@ var quickAlgoInterface = {
             if (!this.licenses[license])
                 licenseTxt += license;
             else {
-                licenseTxt += license + " <span id='aboutLicenseIcon' class='icon fas fa-question-circle' onclick='window.open(\""
-                    + this.licenses[license] + "\", \"_blank\");'></span>";
+                licenseTxt += license + " " + getAboutLicenseButton();
             }
             aboutAuthorsLicenseSection = "<p>" + this.strings.authors + " " + authors +"</p>" +
                 "           <p>" + licenseTxt + "</p>";
@@ -454,9 +476,11 @@ var quickAlgoInterface = {
 
             var licenseInput = null;
             if (!(license in this.licenses)) {
+                licenseDropdown += " " + getAboutLicenseButton(true);
                 licenseInput = " <input id='aboutLicenseInput' type='text' name='chooseLicenseTxt' value='"
                     + license + "' placeholder='" + this.strings.otherLicense + "'>";
             } else {
+                licenseDropdown += " " + getAboutLicenseButton(false);
                 licenseInput = " <input id='aboutLicenseInput' type='text' name='chooseLicenseTxt' value='' " +
                     "style='display: none;' placeholder='" + this.strings.otherLicense + "'>"
             }
@@ -465,7 +489,7 @@ var quickAlgoInterface = {
 
             aboutAuthorsLicenseSection += licenseDropdown + licenseInput + "<br/>";
 
-            var saveButton = "<button id='aboutSaveButton'>Sauvegarder</button>";
+            var saveButton = "<button id='aboutSaveButton'>" + this.strings.saveAndQuit + "</button>";
             aboutAuthorsLicenseSection += saveButton;
         }
 
@@ -495,8 +519,6 @@ var quickAlgoInterface = {
             "</div>";
 
         window.displayHelper.showPopupDialog(aboutHtml);
-
-        var that = this;
 
         /**
          * This method allow us to get the new license from the dropdown or the input box according to this predicate:
@@ -540,9 +562,11 @@ var quickAlgoInterface = {
         $('#aboutLicenseDropdown').change(function() {
             var val = $('#aboutLicenseDropdown option:selected').text();
             if (val === that.strings.other) {
+                $("#aboutLicenseIcon").hide();
                 $("#aboutLicenseInput").show();
             } else {
                 $("#aboutLicenseInput").hide();
+                $("#aboutLicenseIcon").show();
             }
         });
 

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -569,14 +569,6 @@ var quickAlgoInterface = {
                 $("#aboutLicenseIcon").show();
             }
         });
-
-        /*
-        $('#aboutLicenseInput').on('input', function() {
-            if ($('#aboutLicenseInput').val() != "")
-                $("#aboutLicenseDropdown").prop("disabled", true);
-            else
-                $("#aboutLicenseDropdown").prop("disabled", false);
-        });*/
     },
 
     loadPrograms: function(formElement) {

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -435,6 +435,8 @@ var quickAlgoInterface = {
             authorsTxt += "<input id='aboutAuthorsInput' type='text' name='author' value='" + authors + "'>";
 
 
+            // For the license, the user has 2 choices: He can select a license from the dropdown or write manually
+            // the license that he want to use
             var disableDropdown = "";
             if (!(license in this.licenses))
                 disableDropdown = "disabled=''";

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -20,7 +20,7 @@ var quickAlgoInterface = {
     editorReadOnly: false,
     options: {},
     capacityPopupDisplayed: {},
-    userTaskData: null, // contain the subject and title
+    userTaskData: null, // contain the subject and title, and also the about
     keypadData: {
         value: '',
         callbackModify: null,
@@ -132,7 +132,14 @@ var quickAlgoInterface = {
         if (!this.userTaskData) {
             this.userTaskData = {
                 title: document.title,
-                subject: $(".exerciseText").first().text()
+                subject: $(".exerciseText").first().text(),
+                about: {
+                    authors: "France-Ioi",
+                    license: "free",
+                    type: null // null type mean no type and no text will be displayed for this
+                    // available types:
+                    // - quick-pi: will display the quickpi info text
+                }
             };
         } else {
             this.loadSubjectFromUserTaskData();
@@ -238,6 +245,7 @@ var quickAlgoInterface = {
                         this.strings.reloadProgram +
                     "</div>" +
                     "<div rel='edit' class='item' onclick='quickAlgoInterface.editorBtn(\"edit\");'><span class='fas fa-pencil-alt'></span>" + this.strings.editButton + "</div>" +
+                    "<div rel='about' class='item' onclick='quickAlgoInterface.editorBtn(\"about\");'><span class='fas fa-question-circle'></span>" + this.strings.about + "</div>" +
                     "<div rel='best-answer' class='item' onclick='quickAlgoInterface.editorBtn(\"best-answer\");'><span class='fas fa-trophy'></span> " + this.strings.loadBestAnswer + "</div>" +
                     "<div rel='blockly-python' class='item' onclick='quickAlgoInterface.editorBtn(\"blockly-python\");'><span class='fas fa-file-code'></span> " + this.strings.blocklyToPython + "</div>" +
                 "</div>" +
@@ -283,6 +291,8 @@ var quickAlgoInterface = {
             displayHelper.restartAll();
         } else if (btn == 'edit') {
             this.openEditExercise();
+        } else if (btn == 'about') {
+            this.openAbout();
         } else if (btn == 'best-answer') {
             displayHelper.retrieveAnswer();
         } else if (btn == 'blockly-python') {
@@ -347,6 +357,45 @@ var quickAlgoInterface = {
             that.userTaskData.subject = newSubject;
             that.loadSubjectFromUserTaskData();
         });
+    },
+
+    openAbout: function() {
+        var authors = this.userTaskData.about.authors;
+
+        var licenseTxt = "Libre - Vous pouvez modifier ce project";
+        if (this.userTaskData.about.license !== "free")
+            licenseTxt = "Copyright - Vous n'avez pas le droit de modifier ce projet";
+
+        var typeTxt = "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>";
+        if (this.userTaskData.about.type && this.userTaskData.about.type === "quickpi") {
+            typeTxt = "Subject powered by <a href='https://quick-pi.org/'>Quick-Pi</a> <br/>" +
+                "from <a href='http://www.france-ioi.org/'>France-IOI</a>"
+        } // TODO: add other possible texts here (or add an object to change the option easier)
+
+
+        var aboutHtml = "<div class=\"content connectPi qpi\">" +
+            "    <div class=\"panel-heading\">" +
+            "        <h2 class=\"sectionTitle\">" +
+            "            <span class=\"iconTag\"><i class=\"icon fas fa-question-circle\"></i></span>" +
+                            this.strings.about +
+            "        </h2>" +
+            "    <div class=\"exit\" id=\"aboutclose\"><i class=\"icon fas fa-times\"></i></div>" +
+            "    </div>" +
+            "    <div class=\"panel-body\">" +
+            "        <div id=\"aboutAuthors\">" +
+            "           <label>Authors:</label>" +
+            "           <p>" + authors + "</p>" +
+            "        </div>" +
+            "        <div id='aboutLicense'>" +
+            "           <label>license</label> " + licenseTxt + // TODO: internationalisation on license
+            "       </div>" +
+            "       <div id='aboutFranceIOI'>" +
+            "           <p>" + typeTxt + "</p>" +
+            "       </div>" +
+            "    </div>" +
+            "</div>";
+
+        window.displayHelper.showPopupDialog(aboutHtml);
     },
 
     loadPrograms: function(formElement) {

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -29,9 +29,9 @@ var quickAlgoInterface = {
     // Contain all the licenses supported with their link
     // There is also the "copyright" license or other license that the user can write himself
     licenses: {
-        "CC BY-SA": "https://creativecommons.org/licenses/by-sa/4.0/deed.fr",
-        "CC BY-NC-SA": "https://creativecommons.org/licenses/by-nc-sa/4.0/?ref=ccsearch&atype=rich",
-        "CC BY": "https://creativecommons.org/licenses/by/4.0/deed.fr"
+        "CC BY-SA 4.0": "https://creativecommons.org/licenses/by-sa/4.0/deed.fr",
+        "CC BY-NC-SA 4.0": "https://creativecommons.org/licenses/by-nc-sa/4.0/?ref=ccsearch&atype=rich",
+        "CC BY 4.0": "https://creativecommons.org/licenses/by/4.0/deed.fr"
     },
 
     enterFullscreen: function() {
@@ -143,7 +143,7 @@ var quickAlgoInterface = {
                 subject: $(".exerciseText").first().text(),
                 about: {
                     authors: "France-Ioi",
-                    license: "CC-BY-SA"
+                    license: "CC BY-SA 4.0"
                 }
             };
         } else {
@@ -419,19 +419,19 @@ var quickAlgoInterface = {
 
         // if the license is not inside of our predefined licenses then we write it without "more details" button
         if (!this.options.canEditSubject) {
-            var licenseTxt = "License: ";
+            var licenseTxt = this.strings.license;
             if (!this.licenses[license])
                 licenseTxt += license;
             else {
                 licenseTxt += license + " <span id='aboutLicenseIcon' class='icon fas fa-question-circle' onclick='window.open(\""
                     + this.licenses[license] + "\", \"_blank\");'></span>";
             }
-            aboutAuthorsLicenseSection = "<p>Autheurs: " + authors +"</p>" +
+            aboutAuthorsLicenseSection = "<p>" + this.strings.authors + " " + authors +"</p>" +
                 "           <p>" + licenseTxt + "</p>";
         } else {
             aboutAuthorsLicenseSection = "";
 
-            var authorsTxt = "<label for='author'>Auteurs: </label>";
+            var authorsTxt = "<label for='author'>" + this.strings.authors + "</label>";
             authorsTxt += "<input id='aboutAuthorsInput' type='text' name='author' value='" + authors + "'>";
 
 
@@ -440,7 +440,7 @@ var quickAlgoInterface = {
             var disableDropdown = "";
             if (!(license in this.licenses))
                 disableDropdown = "disabled=''";
-            var licenseDropdown = "<label for='chooseLicense'>Choisissez votre license:</label>" +
+            var licenseDropdown = "<label for='chooseLicense'>" + this.strings.license + "</label>" +
                 "<select name='chooseLicense' id='aboutLicenseDropdown' " + disableDropdown + ">";
             for (var licenseName in this.licenses) {
                 var selected = "";

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -367,23 +367,41 @@ var quickAlgoInterface = {
     openAbout: function() {
         var authors = this.userTaskData.about.authors;
 
-        var licenseTxt = "License: ";
         var license = this.userTaskData.about.license;
+
+        var aboutAuthorsLicenseSection = null;
 
         // if the license is not inside of our predefined licenses then we write it without "more details" button
         if (!this.options.canEditSubject) {
+            var licenseTxt = "License: ";
             if (!this.licenses[license])
                 licenseTxt += license;
             else {
                 licenseTxt += license + " <span id='aboutLicenseIcon' class='icon fas fa-question-circle' onclick='window.open(\""
                     + this.licenses[license] + "\", \"_blank\");'></span>";
             }
+            aboutAuthorsLicenseSection = "<p>Autheurs: " + authors +"</p>" +
+                "           <p>" + licenseTxt + "</p>";
         } else {
-            licenseTxt = "<label for='chooseLicense'>Choisissez votre license:</label>" +
+            aboutAuthorsLicenseSection = "";
+
+            var authorsTxt = "<label for='author'>Auteurs: </label>";
+            authorsTxt += "<input type='text' name='author' value='" + authors + "'>";
+
+            var licenseTxt = "<label for='chooseLicense'>Choisissez votre license:</label>" +
                 "<select name='chooseLicense' id='aboutLicenseDropdown'>";
-            for (var licenseName in this.licenses)
-                licenseTxt += "<option value='" + licenseName + "'>" + licenseName + "</option>";
+            for (var licenseName in this.licenses) {
+                var selected = "";
+                if (license == licenseName)
+                    selected = "selected";
+                licenseTxt += "<option value='" + licenseName + "'" + selected + ">" + licenseName + "</option>";
+            }
             licenseTxt += "</select>";
+
+            var saveButton = "<button></button>"; // TODO
+
+            aboutAuthorsLicenseSection += authorsTxt;
+            aboutAuthorsLicenseSection += licenseTxt;
         }
 
         var typeTxt = this.strings.exerciseTypeAbout["default"];
@@ -402,8 +420,7 @@ var quickAlgoInterface = {
             "    </div>" +
             "    <div class=\"panel-body\" id='aboutPanel'>"+
             "       <div id='aboutAuthorsLicense'>" +
-            "           <p>Autheurs: " + authors +"</p>" +
-            "           <p>" + licenseTxt + "</p>" +
+                        aboutAuthorsLicenseSection +
             "       </div>" +
             "       <div id='aboutFranceIOI'>" +
             "           <br/>" +
@@ -418,6 +435,8 @@ var quickAlgoInterface = {
             $('#popupMessage').hide();
             window.displayHelper.popupMessageShown = false;
         });
+
+        // TODO: action on the button
     },
 
     loadPrograms: function(formElement) {

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -319,7 +319,7 @@ var quickAlgoInterface = {
      * @return true if we can exit without problem, false otherwise
      * @throws An error, if two compare.size() is not a multiple of 2
      */
-    _handleConfirmationExitWindow: function(...toCompare) {
+    _handleConfirmationExitWindow: function(toCompare) {
         if (toCompare.length % 2 != 0) {
             // this should never happen in prod, if an error is thrown the error come from the programmer.
             throw "interface-mobileFirst.js: _handleConfirmationExitWindow: toCompare must be a multiple of 2, you did"
@@ -352,8 +352,8 @@ var quickAlgoInterface = {
      * @public Because we must use it inside of button "onClick" functions, so we can't make it "private" because the
      * strict private convention is not respected here (we must use that.closePopupWithConfirmation inside of a button).
      */
-    closePopupWithConfirmation: function(...toCompare) {
-        if (this._handleConfirmationExitWindow(...toCompare)) {
+    closePopupWithConfirmation: function(toCompare) {
+        if (this._handleConfirmationExitWindow(toCompare)) {
             this.closePopup();
         }
     },
@@ -395,7 +395,7 @@ var quickAlgoInterface = {
             var newDesc = $("#editExerciseDescriptionTextarea").val();
             var oldTitle = that.userTaskData.title;
             var oldDescription = that.userTaskData.subject;
-            that.closePopupWithConfirmation(newTitle, oldTitle, newDesc, oldDescription);
+            that.closePopupWithConfirmation([newTitle, oldTitle, newDesc, oldDescription]);
         });
 
         $("#saveExerciseChanges").click(function() {
@@ -540,7 +540,7 @@ var quickAlgoInterface = {
                 var newLicense = getLicenseChanges();
                 var oldAuthors = that.userTaskData.about.authors;
                 var oldLicense = that.userTaskData.about.license;
-                that.closePopupWithConfirmation(newAuthors, oldAuthors, newLicense, oldLicense);
+                that.closePopupWithConfirmation([newAuthors, oldAuthors, newLicense, oldLicense]);
             } else {
                 that.closePopup();
             }

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -434,40 +434,38 @@ var quickAlgoInterface = {
             var authorsTxt = "<label for='author'>" + this.strings.authors + "</label>";
             authorsTxt += "<input id='aboutAuthorsInput' type='text' name='author' value='" + authors + "'>";
 
+            var licenseOther = "";
 
-            // For the license, the user has 2 choices: He can select a license from the dropdown or write manually
-            // the license that he want to use
-            var disableDropdown = "";
             if (!(license in this.licenses))
-                disableDropdown = "disabled=''";
-            var licenseDropdown = "<label for='chooseLicense'>" + this.strings.license + "</label>" +
-                "<select name='chooseLicense' id='aboutLicenseDropdown' " + disableDropdown + ">";
+                licenseOther = "selected";
+
+            var licenseDropdown = "<p>" + this.strings.license + "</p>" +
+                "<select name='chooseLicense' id='aboutLicenseDropdown'>";
             for (var licenseName in this.licenses) {
                 var selected = "";
                 if (license === licenseName)
                     selected = "selected";
                 licenseDropdown += "<option value='" + licenseName + "'" + selected + ">" + licenseName + "</option>";
             }
+            licenseDropdown += "<option value='" + this.strings.other + "' " + licenseOther + ">" + this.strings.other
+                + "</option>";
             licenseDropdown += "</select>";
 
-            var licenseInputValue = "";
-            if (!(license in this.licenses))
-                licenseInputValue = license;
 
-            var licenseInput = "<label for='chooseLicenseTxt'>Écrivez votre license</label>" +
-                "<input id='aboutLicenseInput' type='text' name='chooseLicenseTxt' value=" + licenseInputValue + ">";
-
-            var licenseRealHtml = "<table id='licenseTable'>" +
-                "   <tr>" +
-                "       <th>" + licenseDropdown + "</th>" +
-                "       <th>" + licenseInput + "</th>" +
-                "   </tr>" +
-                "</table>";
-
-            var saveButton = "<button id='aboutSaveButton'>Sauvegarder</button>";
+            var licenseInput = null;
+            if (!(license in this.licenses)) {
+                licenseInput = " <input id='aboutLicenseInput' type='text' name='chooseLicenseTxt' value='"
+                    + license + "' placeholder='" + this.strings.otherLicense + "'>";
+            } else {
+                licenseInput = " <input id='aboutLicenseInput' type='text' name='chooseLicenseTxt' value='' " +
+                    "style='display: none;' placeholder='" + this.strings.otherLicense + "'>"
+            }
 
             aboutAuthorsLicenseSection += authorsTxt;
-            aboutAuthorsLicenseSection += licenseRealHtml;
+
+            aboutAuthorsLicenseSection += licenseDropdown + licenseInput + "<br/>";
+
+            var saveButton = "<button id='aboutSaveButton'>Sauvegarder</button>";
             aboutAuthorsLicenseSection += saveButton;
         }
 
@@ -502,16 +500,16 @@ var quickAlgoInterface = {
 
         /**
          * This method allow us to get the new license from the dropdown or the input box according to this predicate:
-         * if the input box is empty then the value inside of the dropdown is taken, otherwise it is the value of the
-         * input box that is taken.
+         * if the dropdown has this.strings.other as selection, then we select the value of the input box.
          * @return The new license
          */
         function getLicenseChanges() {
-            var licenseTxt = $('#aboutLicenseInput').val();
-            if (licenseTxt != "")
-                return licenseTxt;
-            else
-                return $('#aboutLicenseDropdown option:selected').text();
+            var selectedDropdown = $('#aboutLicenseDropdown option:selected').text();
+            if (selectedDropdown === that.strings.other) {
+                return $('#aboutLicenseInput').val();
+            } else {
+                return selectedDropdown;
+            }
         }
 
         $("#aboutclose").click(function() {
@@ -529,18 +527,32 @@ var quickAlgoInterface = {
         $('#aboutSaveButton').click(function() {
             var newAuthors = $('#aboutAuthorsInput').val();
             var newLicense = getLicenseChanges();
+            if (!newLicense) {
+                alert(that.strings.pleaseSpecifyLicense);
+                return;
+            }
             that.userTaskData.about.authors = newAuthors;
             that.userTaskData.about.license = newLicense;
             $('#popupMessage').hide();
             window.displayHelper.popupMessageShown = false;
         });
 
+        $('#aboutLicenseDropdown').change(function() {
+            var val = $('#aboutLicenseDropdown option:selected').text();
+            if (val === that.strings.other) {
+                $("#aboutLicenseInput").show();
+            } else {
+                $("#aboutLicenseInput").hide();
+            }
+        });
+
+        /*
         $('#aboutLicenseInput').on('input', function() {
             if ($('#aboutLicenseInput').val() != "")
                 $("#aboutLicenseDropdown").prop("disabled", true);
             else
                 $("#aboutLicenseDropdown").prop("disabled", false);
-        });
+        });*/
     },
 
     loadPrograms: function(formElement) {

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -26,6 +26,13 @@ var quickAlgoInterface = {
         callbackModify: null,
         callbackFinished: null
         },
+    // Contain all the licenses supported with their link
+    // There is also the "copyright" license or other license that the user can write himself
+    licenses: {
+        "CC BY-SA": "https://creativecommons.org/licenses/by-sa/4.0/deed.fr",
+        "CC BY-NC-SA": "https://creativecommons.org/licenses/by-nc-sa/4.0/?ref=ccsearch&atype=rich",
+        "CC BY": "https://creativecommons.org/licenses/by/4.0/deed.fr"
+    },
 
     enterFullscreen: function() {
         var el = document.documentElement;
@@ -130,15 +137,13 @@ var quickAlgoInterface = {
 
         // if we don't have userTaskData loaded, then we load it from the subject
         if (!this.userTaskData) {
+            // default userTaskData
             this.userTaskData = {
                 title: document.title,
                 subject: $(".exerciseText").first().text(),
                 about: {
                     authors: "France-Ioi",
-                    license: "free",
-                    type: null // null type mean no type and no text will be displayed for this
-                    // available types:
-                    // - quick-pi: will display the quickpi info text
+                    license: "CC-BY-SA"
                 }
             };
         } else {
@@ -362,40 +367,57 @@ var quickAlgoInterface = {
     openAbout: function() {
         var authors = this.userTaskData.about.authors;
 
-        var licenseTxt = "Libre - Vous pouvez modifier ce project";
-        if (this.userTaskData.about.license !== "free")
-            licenseTxt = "Copyright - Vous n'avez pas le droit de modifier ce projet";
+        var licenseTxt = "License: ";
+        var license = this.userTaskData.about.license;
 
-        var typeTxt = "Subject powered by <a href='http://www.france-ioi.org/'>France-IOI</a>";
-        if (this.userTaskData.about.type && this.userTaskData.about.type === "quickpi") {
-            typeTxt = "Subject powered by <a href='https://quick-pi.org/'>Quick-Pi</a> <br/>" +
-                "from <a href='http://www.france-ioi.org/'>France-IOI</a>"
-        } // TODO: add other possible texts here (or add an object to change the option easier)
+        // if the license is not inside of our predefined licenses then we write it without "more details" button
+        if (!this.options.canEditSubject) {
+            if (!this.licenses[license])
+                licenseTxt += license;
+            else {
+                licenseTxt += license + " <span id='aboutLicenseIcon' class='icon fas fa-question-circle' onclick='window.open(\""
+                    + this.licenses[license] + "\", \"_blank\");'></span>";
+            }
+        } else {
+            licenseTxt = "<label for='chooseLicense'>Choisissez votre license:</label>" +
+                "<select name='chooseLicense' id='aboutLicenseDropdown'>";
+            for (var licenseName in this.licenses)
+                licenseTxt += "<option value='" + licenseName + "'>" + licenseName + "</option>";
+            licenseTxt += "</select>";
+        }
+
+        var typeTxt = this.strings.exerciseTypeAbout["default"];
+        if (this.context.title)
+            typeTxt = this.strings.exerciseTypeAbout[this.context.title];
+
 
 
         var aboutHtml = "<div class=\"content connectPi qpi\">" +
             "    <div class=\"panel-heading\">" +
             "        <h2 class=\"sectionTitle\">" +
             "            <span class=\"iconTag\"><i class=\"icon fas fa-question-circle\"></i></span>" +
-                            this.strings.about +
+                        this.strings.about +
             "        </h2>" +
             "    <div class=\"exit\" id=\"aboutclose\"><i class=\"icon fas fa-times\"></i></div>" +
             "    </div>" +
-            "    <div class=\"panel-body\">" +
-            "        <div id=\"aboutAuthors\">" +
-            "           <label>Authors:</label>" +
-            "           <p>" + authors + "</p>" +
-            "        </div>" +
-            "        <div id='aboutLicense'>" +
-            "           <label>license</label> " + licenseTxt + // TODO: internationalisation on license
+            "    <div class=\"panel-body\" id='aboutPanel'>"+
+            "       <div id='aboutAuthorsLicense'>" +
+            "           <p>Autheurs: " + authors +"</p>" +
+            "           <p>" + licenseTxt + "</p>" +
             "       </div>" +
             "       <div id='aboutFranceIOI'>" +
+            "           <br/>" +
             "           <p>" + typeTxt + "</p>" +
             "       </div>" +
             "    </div>" +
             "</div>";
 
         window.displayHelper.showPopupDialog(aboutHtml);
+
+        $("#aboutclose").click(function() {
+            $('#popupMessage').hide();
+            window.displayHelper.popupMessageShown = false;
+        });
     },
 
     loadPrograms: function(formElement) {

--- a/pemFioi/quickAlgo/interface-mobileFirst.js
+++ b/pemFioi/quickAlgo/interface-mobileFirst.js
@@ -366,13 +366,13 @@ var quickAlgoInterface = {
      * @param hidden If the button should be hidden or not (or no argument in this case the button is shown)
      * @return {string}  The html for the button
      */
-    _getAboutLicenseButton: function(hidden) {
+    _getAboutLicenseButton: function(hidden, license) {
         if (!hidden)
             hidden = "";
         else
             hidden = "style='display: none;'";
         return "<span id='aboutLicenseIcon' class='icon fas fa-question-circle' onclick='window.open(\""
-            + that.licenses[this.userTaskData.about.license] + "\", \"_blank\");' " + hidden + "></span>";
+            + this.licenses[license] + "\", \"_blank\");' " + hidden + "></span>";
     },
 
     openEditExercise: function() {
@@ -409,11 +409,11 @@ var quickAlgoInterface = {
 
         var licenseInput = null;
         if (!(license in this.licenses)) {
-            licenseDropdown += " " + this._getAboutLicenseButton(true);
+            licenseDropdown += " " + this._getAboutLicenseButton(true, license);
             licenseInput = " <input id='aboutLicenseInput' type='text' name='chooseLicenseTxt' value='"
                 + license + "' placeholder='" + this.strings.otherLicense + "'>";
         } else {
-            licenseDropdown += " " + this._getAboutLicenseButton(false);
+            licenseDropdown += " " + this._getAboutLicenseButton(false, license);
             licenseInput = " <input id='aboutLicenseInput' type='text' name='chooseLicenseTxt' value='' " +
                 "style='display: none;' placeholder='" + this.strings.otherLicense + "'>"
         }
@@ -484,6 +484,7 @@ var quickAlgoInterface = {
                 $("#aboutLicenseInput").show();
             } else {
                 $("#aboutLicenseInput").hide();
+                $("#aboutLicenseIcon").attr("onclick", "window.open(\"" + that.licenses[val] + "\", \"_blank\");");
                 $("#aboutLicenseIcon").show();
             }
         });
@@ -504,15 +505,6 @@ var quickAlgoInterface = {
         });
     },
 
-    _getAboutLicenseButton: function(hidden) {
-        if (!hidden)
-            hidden = "";
-        else
-            hidden = "style='display: none;'";
-        return "<span id='aboutLicenseIcon' class='icon fas fa-question-circle' onclick='window.open(\""
-            + this.licenses[this.userTaskData.about.license] + "\", \"_blank\");' " + hidden + "></span>";
-    },
-
     openAbout: function() {
         var that = this;
 
@@ -525,7 +517,7 @@ var quickAlgoInterface = {
         if (!this.licenses[license])
             licenseTxt += license;
         else
-            licenseTxt += license + " " + this._getAboutLicenseButton(false);
+            licenseTxt += license + " " + this._getAboutLicenseButton(false, license);
 
         var aboutAuthorsLicenseSection = "<p>" + this.strings.authors + " " + authors +"</p>" +
                 "           <p>" + licenseTxt + "</p>";

--- a/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
+++ b/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
@@ -1897,3 +1897,12 @@ button.showLongIntro .icon {
   display: flex;
   justify-content: right;
 }
+.panel-body #aboutAuthorsLicense {
+  font-size: 1.5em;
+}
+#aboutPanel p {
+  text-align: center;
+}
+#aboutLicenseIcon {
+  color: #4a90e2;
+}

--- a/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
+++ b/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
@@ -1909,3 +1909,6 @@ button.showLongIntro .icon {
 #aboutAuthorsLicense {
   text-align: center;
 }
+#aboutLicenseIcon {
+  cursor: pointer;
+}

--- a/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
+++ b/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
@@ -1906,3 +1906,10 @@ button.showLongIntro .icon {
 #aboutLicenseIcon {
   color: #4a90e2;
 }
+#aboutAuthorsLicense {
+  text-align: center;
+}
+#licenseTable {
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
+++ b/pemFioi/quickAlgo/quickAlgo-mobileFirst.css
@@ -1909,7 +1909,3 @@ button.showLongIntro .icon {
 #aboutAuthorsLicense {
   text-align: center;
 }
-#licenseTable {
-  margin-left: auto;
-  margin-right: auto;
-}


### PR DESCRIPTION
This branch allow to add the "about" section is the menu, in edition and without edition.

In the about menu without edition available:
You see the authors, the license and a short line about quickpi or the default line written in i18n.js, if the license is a part of predefined licenses that we have, (only 3 yet), then there is a "?" near the license that open a new widget with the 

In edition:
You can write in the field "authors",
For the edition of the license:
There is a dropdown with the "?" which allow you to open more info about the license near it, you can select a license "other" and a text input appear near it to replace the "?" in which you can write your custom license
And a short text that cannot be changed is displayed about france-ioi or quickpi