### PR TITLE
[Fix] IE8 + graph library + text inside vertex

### DIFF
--- a/pemFioi/graph-mouse-1.1.js
+++ b/pemFioi/graph-mouse-1.1.js
@@ -351,7 +351,9 @@ function VertexDragger(settings) {
          for(var rid in settings.visualGraph.vertexRaphaels) {
             var vrs = settings.visualGraph.vertexRaphaels[rid];
             for(var i = 0; i < vrs.length; i++) {
-               if(vrs[i].node === (event.target || event.srcElement)) {
+               if(vrs[i].node === (event.target || event.srcElement)
+                   || vrs[i].node === (event.target.parentElement || event.target.parentNode || event.srcElement.parentElement || event.srcElement.parentNode)
+               ) {
                   self.elementID = rid;
                }
             }


### PR DESCRIPTION
When RaphaëlJS creates a text element, it creates an inner element `tspan` inside the text element. This didn't work with the recent IE8 Fix, cf https://github.com/France-ioi/bebras-modules/commit/f676a0caa31694714c733b37d57dedfe76455aaa