### PR TITLE
Wrong state cloud message

### DIFF
--- a/pemFioi/quickAlgo/utils.js
+++ b/pemFioi/quickAlgo/utils.js
@@ -22,6 +22,47 @@ var arrayContains = function(array, needle) {
       }
    }
    return false;
+};
+
+/**
+ * This method allow us to verify if the current value is primitive. A primitive is a string or a number or boolean
+ * (any value that can be safely compared
+ * @param obj The object to check if it is a primitive or not
+ * @return {boolean} true if object is primitive, false otherwise
+ */
+function isPrimitive(obj)
+{
+    return (obj !== Object(obj));
+}
+
+/**
+ * THis function allow us to compare two objects. Do not call with {@code null} or {@code undefined}
+ * Be careful! Do not use this with circular objects.
+ * @param obj1 The first object to compare
+ * @param obj2 The second object to compare
+ * @return {boolean} true if objects are equals, false otherwise.
+ */
+function deepEqual(obj1, obj2) {
+
+    if (obj1 === obj2) // it's just the same object. No need to compare.
+        return true;
+
+    // if one is primitive and not the other, then we can return false. If both are primitive, then the up
+    // comparison can return true
+    if (isPrimitive(obj1) || isPrimitive(obj2))
+        return false;
+
+    if (Object.keys(obj1).length !== Object.keys(obj2).length)
+        return false;
+
+    // compare objects with same number of keys
+    for (var key in obj1)
+    {
+        if (!(key in obj2)) return false; //other object doesn't have this prop
+        if (!deepEqual(obj1[key], obj2[key])) return false;
+    }
+
+    return true;
 }
 
 var highlightPause = false;
@@ -54,7 +95,7 @@ if (!String.prototype.format) {
 
 
 function showModal(id) {
-   var el = '#' + id
+   var el = '#' + id;
    $(el).show();
 }
 function closeModal(id) {

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -385,7 +385,7 @@ var quickPiLocalLanguageStrings = {
             cloudUnexpectedKeyCorrection: "Test échoué : La clée {0} n'étais pas attendu dans le cloud",
             cloudPrimitiveWrongKey: "Test échoué : À la clée {0} du cloud, la valeur {1} était attendue au lieu de {2}",
             cloudArrayWrongKey: "Test échoué : Le tableau à la clée {0} du cloud diffère de celui attendu.",
-            cloudDictionnaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu",
+            cloudDictionaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu",
             cloudWrongType: "Test échoué : Vous avez stocké une valeur de type \"{0}\" dans la clé {1} du cloud, mais le type \"{2}\" était attendu.",
 
             cloudKeyNotExists: "La clé n'existe pas : {0} ",
@@ -821,7 +821,7 @@ var quickPiLocalLanguageStrings = {
             state: "Estado",
 
             cloudTypes: {
-                object: "Dictionnaire", // TODO: translate (dictionnary)
+                object: "Dictionnaire", // TODO: translate (dictionary)
                 array: "Tableau", // TODO: translate
                 boolean: "Booléen", // TODO: translate
                 number: "Nombre", // TODO: translate
@@ -832,7 +832,7 @@ var quickPiLocalLanguageStrings = {
             cloudUnexpectedKeyCorrection: "Test échoué : La clée {0} n'étais pas attendu dans le cloud", // TODO: translate
             cloudPrimitiveWrongKey: "Test échoué : À la clée {0} du cloud, la valeur {1} était attendue au lieu de {2}", // TODO: translate
             cloudArrayWrongKey: "Test échoué : Le tableau à la clée {0} du cloud diffère de celui attendu.", // TODO: translate
-            cloudDictionnaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu", // TODO: translate
+            cloudDictionaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu", // TODO: translate
             cloudWrongType: "Test échoué : Vous avez stocké une valeur de type \"{0}\" dans la clé {1} du cloud, mais le type \"{2}\" était attendu.", // TODO: translate
 
             cloudKeyNotExists: "La llave no existe : {0} ",
@@ -1266,7 +1266,7 @@ var quickPiLocalLanguageStrings = {
             state: "State",
 
             cloudTypes: {
-                object: "Dictionnaire", // TODO: translate (dictionnary)
+                object: "Dictionnaire", // TODO: translate (dictionary)
                 array: "Tableau", // TODO: translate
                 boolean: "Booléen", // TODO: translate
                 number: "Nombre", // TODO: translate
@@ -1277,7 +1277,7 @@ var quickPiLocalLanguageStrings = {
             cloudUnexpectedKeyCorrection: "Test échoué : La clée {0} n'étais pas attendu dans le cloud", // TODO: translate
             cloudPrimitiveWrongKey: "Test échoué : À la clée {0} du cloud, la valeur {1} était attendue au lieu de {2}", // TODO: translate
             cloudArrayWrongKey: "Test échoué : Le tableau à la clée {0} du cloud diffère de celui attendu.", // TODO: translate
-            cloudDictionnaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu", // TODO: translate
+            cloudDictionaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu", // TODO: translate
             cloudWrongType: "Test échoué : Vous avez stocké une valeur de type \"{0}\" dans la clé {1} du cloud, mais le type \"{2}\" était attendu.", // TODO: translate
 
             cloudKeyNotExists: "La chiave non esiste : {0} ",
@@ -2717,7 +2717,7 @@ var getContext = function (display, infos, curLevel) {
                     case valueType.ARRAY:
                         return strings.messages.cloudArrayWrongKey.format(keyCompare.key);
                     case valueType.DICTIONARY:
-                        return strings.messages.cloudDictionnaryWrongKey.format(keyCompare.key);
+                        return strings.messages.cloudDictionaryWrongKey.format(keyCompare.key);
                 }
             },
 

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -380,12 +380,12 @@ var quickPiLocalLanguageStrings = {
                 number: "Nombre",
                 string: "Chaîne de caractère"
             },
-            cloudMissingKey: "Test échoué : Il vous manque la clée {0} dans le cloud.",
-            cloudMoreKey: "Test échoué : La clée {0} est en trop dans le cloud",
-            cloudUnexpectedKeyCorrection: "Test échoué : La clée {0} n'étais pas attendu dans le cloud",
-            cloudPrimitiveWrongKey: "Test échoué : À la clée {0} du cloud, la valeur {1} était attendue au lieu de {2}",
-            cloudArrayWrongKey: "Test échoué : Le tableau à la clée {0} du cloud diffère de celui attendu.",
-            cloudDictionaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu",
+            cloudMissingKey: "Test échoué : Il vous manque la clé {0} dans le cloud.",
+            cloudMoreKey: "Test échoué : La clé {0} est en trop dans le cloud",
+            cloudUnexpectedKeyCorrection: "Test échoué : La clé {0} n'étais pas attendu dans le cloud",
+            cloudPrimitiveWrongKey: "Test échoué : À la clé {0} du cloud, la valeur {1} était attendue au lieu de {2}",
+            cloudArrayWrongKey: "Test échoué : Le tableau à la clé {0} du cloud diffère de celui attendu.",
+            cloudDictionaryWrongKey: "Test échoué : Le dictionnaire à la clé {0} diffère de celui attendu",
             cloudWrongType: "Test échoué : Vous avez stocké une valeur de type \"{0}\" dans la clé {1} du cloud, mais le type \"{2}\" était attendu.",
 
             cloudKeyNotExists: "La clé n'existe pas : {0} ",
@@ -827,12 +827,12 @@ var quickPiLocalLanguageStrings = {
                 number: "Nombre", // TODO: translate
                 string: "Chaîne de caractère" // TODO: translate
             },
-            cloudMissingKey: "Test échoué : Il vous manque la clée {0} dans le cloud.", // TODO: translate
-            cloudMoreKey: "Test échoué : La clée {0} est en trop dans le cloud", // TODO: translate
-            cloudUnexpectedKeyCorrection: "Test échoué : La clée {0} n'étais pas attendu dans le cloud", // TODO: translate
-            cloudPrimitiveWrongKey: "Test échoué : À la clée {0} du cloud, la valeur {1} était attendue au lieu de {2}", // TODO: translate
-            cloudArrayWrongKey: "Test échoué : Le tableau à la clée {0} du cloud diffère de celui attendu.", // TODO: translate
-            cloudDictionaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu", // TODO: translate
+            cloudMissingKey: "Test échoué : Il vous manque la clé {0} dans le cloud.", // TODO: translate
+            cloudMoreKey: "Test échoué : La clé {0} est en trop dans le cloud", // TODO: translate
+            cloudUnexpectedKeyCorrection: "Test échoué : La clé {0} n'étais pas attendu dans le cloud", // TODO: translate
+            cloudPrimitiveWrongKey: "Test échoué : À la clé {0} du cloud, la valeur {1} était attendue au lieu de {2}", // TODO: translate
+            cloudArrayWrongKey: "Test échoué : Le tableau à la clé {0} du cloud diffère de celui attendu.", // TODO: translate
+            cloudDictionaryWrongKey: "Test échoué : Le dictionnaire à la clé {0} diffère de celui attendu", // TODO: translate
             cloudWrongType: "Test échoué : Vous avez stocké une valeur de type \"{0}\" dans la clé {1} du cloud, mais le type \"{2}\" était attendu.", // TODO: translate
 
             cloudKeyNotExists: "La llave no existe : {0} ",
@@ -1272,12 +1272,12 @@ var quickPiLocalLanguageStrings = {
                 number: "Nombre", // TODO: translate
                 string: "Chaîne de caractère" // TODO: translate
             },
-            cloudMissingKey: "Test échoué : Il vous manque la clée {0} dans le cloud.", // TODO: translate
-            cloudMoreKey: "Test échoué : La clée {0} est en trop dans le cloud", // TODO: translate
-            cloudUnexpectedKeyCorrection: "Test échoué : La clée {0} n'étais pas attendu dans le cloud", // TODO: translate
-            cloudPrimitiveWrongKey: "Test échoué : À la clée {0} du cloud, la valeur {1} était attendue au lieu de {2}", // TODO: translate
-            cloudArrayWrongKey: "Test échoué : Le tableau à la clée {0} du cloud diffère de celui attendu.", // TODO: translate
-            cloudDictionaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu", // TODO: translate
+            cloudMissingKey: "Test échoué : Il vous manque la clé {0} dans le cloud.", // TODO: translate
+            cloudMoreKey: "Test échoué : La clé {0} est en trop dans le cloud", // TODO: translate
+            cloudUnexpectedKeyCorrection: "Test échoué : La clé {0} n'étais pas attendu dans le cloud", // TODO: translate
+            cloudPrimitiveWrongKey: "Test échoué : À la clé {0} du cloud, la valeur {1} était attendue au lieu de {2}", // TODO: translate
+            cloudArrayWrongKey: "Test échoué : Le tableau à la clé {0} du cloud diffère de celui attendu.", // TODO: translate
+            cloudDictionaryWrongKey: "Test échoué : Le dictionnaire à la clé {0} diffère de celui attendu", // TODO: translate
             cloudWrongType: "Test échoué : Vous avez stocké une valeur de type \"{0}\" dans la clé {1} du cloud, mais le type \"{2}\" était attendu.", // TODO: translate
 
             cloudKeyNotExists: "La chiave non esiste : {0} ",

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -373,6 +373,21 @@ var quickPiLocalLanguageStrings = {
             port: "Port",
             state: "State",
 
+            cloudTypes: {
+                object: "Dictionnaire",
+                array: "Tableau",
+                boolean: "Booléen",
+                number: "Nombre",
+                string: "Chaîne de caractère"
+            },
+            cloudMissingKey: "Test échoué : Il vous manque la clée {0} dans le cloud.",
+            cloudMoreKey: "Test échoué : La clée {0} est en trop dans le cloud",
+            cloudUnexpectedKeyCorrection: "Test échoué : La clée {0} n'étais pas attendu dans le cloud",
+            cloudPrimitiveWrongKey: "Test échoué : À la clée {0} du cloud, la valeur {1} était attendue au lieu de {2}",
+            cloudArrayWrongKey: "Test échoué : Le tableau à la clée {0} du cloud diffère de celui attendu.",
+            cloudDictionnaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu",
+            cloudWrongType: "Test échoué : Vous avez stocké une valeur de type \"{0}\" dans la clé {1} du cloud, mais le type \"{2}\" était attendu.",
+
             cloudKeyNotExists: "La clé n'existe pas : {0} ",
             cloudWrongValue: "Clé {0} : la valeur {2} n'est pas celle attendue, {1}.",
             cloudUnexpectedKey: "La clé {0} n'est pas une clé attendue",
@@ -407,7 +422,7 @@ var quickPiLocalLanguageStrings = {
             sensorNameServo: "servo",
             sensorNameHumidity: "humidity",
             sensorNamePotentiometer: "pot",
-            sensorNameCloudStore: "cloud",
+            sensorNameCloudStore: "cloud"
         },
         concepts: {
             quickpi_start: 'Créer un programme',
@@ -804,6 +819,22 @@ var quickPiLocalLanguageStrings = {
             name: "Nombre",
             port: "Puerto",
             state: "Estado",
+
+            cloudTypes: {
+                object: "Dictionnaire", // TODO: translate (dictionnary)
+                array: "Tableau", // TODO: translate
+                boolean: "Booléen", // TODO: translate
+                number: "Nombre", // TODO: translate
+                string: "Chaîne de caractère" // TODO: translate
+            },
+            cloudMissingKey: "Test échoué : Il vous manque la clée {0} dans le cloud.", // TODO: translate
+            cloudMoreKey: "Test échoué : La clée {0} est en trop dans le cloud", // TODO: translate
+            cloudUnexpectedKeyCorrection: "Test échoué : La clée {0} n'étais pas attendu dans le cloud", // TODO: translate
+            cloudPrimitiveWrongKey: "Test échoué : À la clée {0} du cloud, la valeur {1} était attendue au lieu de {2}", // TODO: translate
+            cloudArrayWrongKey: "Test échoué : Le tableau à la clée {0} du cloud diffère de celui attendu.", // TODO: translate
+            cloudDictionnaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu", // TODO: translate
+            cloudWrongType: "Test échoué : Vous avez stocké une valeur de type \"{0}\" dans la clé {1} du cloud, mais le type \"{2}\" était attendu.", // TODO: translate
+
             cloudKeyNotExists: "La llave no existe : {0} ",
             cloudWrongValue: "Llave {0}: el valor {2} no es el esperado, {1}.",
             cloudUnexpectedKey: "La llave {0} no es una llave esperada",
@@ -1233,6 +1264,21 @@ var quickPiLocalLanguageStrings = {
             name: "Name",
             port: "Port",
             state: "State",
+
+            cloudTypes: {
+                object: "Dictionnaire", // TODO: translate (dictionnary)
+                array: "Tableau", // TODO: translate
+                boolean: "Booléen", // TODO: translate
+                number: "Nombre", // TODO: translate
+                string: "Chaîne de caractère" // TODO: translate
+            },
+            cloudMissingKey: "Test échoué : Il vous manque la clée {0} dans le cloud.", // TODO: translate
+            cloudMoreKey: "Test échoué : La clée {0} est en trop dans le cloud", // TODO: translate
+            cloudUnexpectedKeyCorrection: "Test échoué : La clée {0} n'étais pas attendu dans le cloud", // TODO: translate
+            cloudPrimitiveWrongKey: "Test échoué : À la clée {0} du cloud, la valeur {1} était attendue au lieu de {2}", // TODO: translate
+            cloudArrayWrongKey: "Test échoué : Le tableau à la clée {0} du cloud diffère de celui attendu.", // TODO: translate
+            cloudDictionnaryWrongKey: "Test échoué : Le dictionnaire à la clée {0} diffère de celui attendu", // TODO: translate
+            cloudWrongType: "Test échoué : Vous avez stocké une valeur de type \"{0}\" dans la clé {1} du cloud, mais le type \"{2}\" était attendu.", // TODO: translate
 
             cloudKeyNotExists: "La chiave non esiste : {0} ",
             cloudWrongValue: "Chiave {0} : il valore {2} non è quello previsto, {1}.",
@@ -1746,7 +1792,6 @@ var getContext = function (display, infos, curLevel) {
         }
         return conceptList;
     }
-
 
     var boardDefinitions = [
         {
@@ -2527,14 +2572,98 @@ var getContext = function (display, infos, curLevel) {
                 function getMissingKey(more, less) {
                     for (var i = 0; i < more.length; i++) {
                         var found = false;
-                        for (var key in less) {
-                            if (key === more[i]) {
+                        for (var j = 0; j < less.length; j++) {
+                            if (more[i] === less[j]) {
                                 found = true;
                                 break;
                             }
                         }
                         if (!found)
                             return more[i];
+                    }
+                    // should never happen because length are different.
+                    return null;
+                }
+
+                // the type of a value in comparison.
+                var valueType = {
+                    // Primitive type are strings and integers
+                    PRIMITIVE: "primitive",
+                    ARRAY: "array",
+                    DICTIONARY: "dictionary",
+                    // if two values are of wrong type then this is returned
+                    WRONG_TYPE: "wrong_type"
+                };
+
+                /**
+                 * This method allow us to compare two keys of the cloud and their values
+                 * @param actual The actual key that we have
+                 * @param expected The expected key that we have
+                 * @return An object containing the type of the return and the key that differ
+                 */
+                function compareKeys(actual, expected) {
+                    function compareArrays(arr1, arr2) {
+                        if (arr1.length != arr2.length)
+                            return false;
+                        for (var i = 0; i < arr1.length; i++) {
+                            for (var j = 0; j < arr2.length; j++) {
+                                if (arr1[i] !== arr2[i])
+                                    return false;
+                            }
+                        }
+                        return true;
+                    }
+                    var actualKeys = Object.keys(actual);
+
+                    for (var i = 0; i < actualKeys.length; i++) {
+                        var actualVal = actual[actualKeys[i]];
+
+                        // they both have the same keys so we can do that.
+                        var expectedVal = expected[actualKeys[i]];
+
+                        if (isPrimitive(expectedVal)) {
+                            // if string with int for example
+                            if (typeof expectedVal !== typeof actualVal) {
+                                return {
+                                    type: valueType.WRONG_TYPE,
+                                    key: actualKeys[i]
+                                }
+                            }
+                            if (expectedVal !== actualVal) {
+                                return {
+                                    type: valueType.PRIMITIVE,
+                                    key: actualKeys[i]
+                                };
+                            }
+                        } else if (Array.isArray(expectedVal)) {
+                            if (!Array.isArray(actualVal)) {
+                                return {
+                                    type: valueType.WRONG_TYPE,
+                                    key: actualKeys[i]
+                                };
+                            }
+                            if (!compareArrays(expectedVal, actualVal)) {
+                                return {
+                                    type: valueType.ARRAY,
+                                    key: actualKeys[i]
+                                };
+                            }
+                            // if we are in a dictionary
+                            // method from: https://stackoverflow.com/questions/38304401/javascript-check-if-dictionary
+                        } else if (expectedVal.constructor == Object) {
+                            if (actualVal.constructor != Object) {
+                                return {
+                                    type: valueType.WRONG_TYPE,
+                                    key: actualKeys[i]
+                                };
+                            }
+                            if (!deepEqual(expectedVal, actualVal)) {
+                                return {
+                                    type: valueType.DICTIONARY,
+                                    key: actualKeys[i]
+                                };
+                            }
+                        }
                     }
                 }
 
@@ -2548,15 +2677,47 @@ var getContext = function (display, infos, curLevel) {
                 var expectedKeys = Object.keys(expected);
                 var actualKeys = Object.keys(actual);
 
-                // TODO: ajouter le temps aussi
                 if (expectedKeys.length != actualKeys.length) {
                     if (expectedKeys.length > actualKeys.length) {
                         var missingKey = getMissingKey(expectedKeys, actualKeys);
-                        return "Test échoué : Il vous manque la clée " + missingKey + " dans le cloud."
+                        return strings.messages.cloudMissingKey.format(missingKey);
                     } else {
                         var additionalKey = getMissingKey(actualKeys, expectedKeys);
-                        return "Test échoué : La clée " + additionalKey + " est en trop dans le cloud";
+                        return strings.messages.cloudMoreKey.format(additionalKey);
                     }
+                }
+
+                // This will return a key that is missing inside of expectedKeys if there is one, otherwise it will return null.
+                var unexpectedKey = getMissingKey(actualKeys, expectedKeys);
+
+                if (unexpectedKey) {
+                    return strings.messages.cloudUnexpectedKeyCorrection.format(unexpectedKey);
+                }
+
+                var keyCompare = compareKeys(actual, expected);
+
+                switch (keyCompare.type) {
+                    case valueType.PRIMITIVE:
+                        return strings.messages.cloudPrimitiveWrongKey.format(keyCompare.key, expected[keyCompare.key], actual[keyCompare.key]);
+                    case valueType.WRONG_TYPE:
+                        var typeActual = typeof actual[keyCompare.key];
+                        var typeExpected = typeof expected[keyCompare.key];
+                        // we need to check if it is an array or a dictionary
+                        if (typeActual == "object") {
+                            if (Array.isArray(actual[keyCompare.key]))
+                                typeActual = "array";
+                        }
+                        if (typeExpected == "object") {
+                            if (Array.isArray(expected[keyCompare.key]))
+                                typeExpected = "array";
+                        }
+                        var typeActualTranslate = quickPiLocalLanguageStrings.fr.messages.cloudTypes[typeActual];
+                        var typeExpectedTranslate = quickPiLocalLanguageStrings.fr.messages.cloudTypes[typeExpected];
+                        return strings.messages.cloudWrongType.format(typeActualTranslate, keyCompare.key, typeExpectedTranslate);
+                    case valueType.ARRAY:
+                        return strings.messages.cloudArrayWrongKey.format(keyCompare.key);
+                    case valueType.DICTIONARY:
+                        return strings.messages.cloudDictionnaryWrongKey.format(keyCompare.key);
                 }
             },
 

--- a/pemFioi/quickpi/blocklyQuickPi_lib.js
+++ b/pemFioi/quickpi/blocklyQuickPi_lib.js
@@ -2517,10 +2517,52 @@ var getContext = function (display, infos, curLevel) {
                 return {};
             },*/
 
-            compareState: function (state1, state2) {
-                return quickPiStore.compareState(state1, state2);
+            getWrongStateString: function(failInfo) {
+                /**
+                 * Call this function when more.length > less.length. It will find the key that is missing inside of the
+                 * less array
+                 * @param more The bigger array, containing one or more key more than less
+                 * @param less Less, the smaller array, he has a key or more missing
+                 */
+                function getMissingKey(more, less) {
+                    for (var i = 0; i < more.length; i++) {
+                        var found = false;
+                        for (var key in less) {
+                            if (key === more[i]) {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found)
+                            return more[i];
+                    }
+                }
+
+                if(!failInfo.expected &&
+                    !failInfo.actual)
+                    return null;
+
+                var expected = failInfo.expected;
+                var actual = failInfo.actual;
+
+                var expectedKeys = Object.keys(expected);
+                var actualKeys = Object.keys(actual);
+
+                // TODO: ajouter le temps aussi
+                if (expectedKeys.length != actualKeys.length) {
+                    if (expectedKeys.length > actualKeys.length) {
+                        var missingKey = getMissingKey(expectedKeys, actualKeys);
+                        return "Test échoué : Il vous manque la clée " + missingKey + " dans le cloud."
+                    } else {
+                        var additionalKey = getMissingKey(actualKeys, expectedKeys);
+                        return "Test échoué : La clée " + additionalKey + " est en trop dans le cloud";
+                    }
+                }
             },
 
+            compareState: function (state1, state2) {
+                return quickPiStore.compareState(state1, state2);
+            }
         },
         {
             name: "clock",

--- a/pemFioi/quickpi/blocklyQuickPi_store.js
+++ b/pemFioi/quickpi/blocklyQuickPi_store.js
@@ -60,14 +60,6 @@
 
         static compareState(state1, state2)
         {
-            if (state1 == null &&
-                state2 == null)
-                return true;
-
-            if (state1 == null ||
-                state2 == null)
-                return false;
-
-            return JSON.stringify(state1) === JSON.stringify(state2);
+            return deepEqual(state1, state2);
         }
 }


### PR DESCRIPTION
This pull request add more explicit messages when user have a cloud error in his correction (at a certain moment, if certain values inside of the cloud are expected and the user has other value inside of the cloud, then this error messages pops).

The cloud error handle many cases:
* If there is more key than expected, it says to the user which key he have more
* If there is less key than expected, it says to the user the missing key
* If there is the same amount of keys but there are some unexpected keys that the user then it says to him the missing keys
* If the keys are correct, then it compare their value:
    * If the value type is different, it says to the user that there is a type error (ex boolean expected but string given)
    * If the value is primitive, then it gives the user both value expected and given
    * If the value is a dictionary or an array, then it says that the array/dictionary is different at the key

There was also an error in the cloudstore comparison: the objects where compared with JSON.stringify, which is unsafe, because this method of comparison depend of the order. I have changed it to a deepCompare function that I have created.

Since cloud was too hard to test in live (I need to create an exercice + correction + solution), I have created a testsuite that test most of cases in the svn in v01/Tests/test-cloud-wrong-state.
You can also test in a real exercise in the svn: v01/QuickPi/ParcoursA.3/3-autotune, difficulty 2 stars with the correction. This exercise fail with the correction given, my code show a more explicit message than before.

You can also find unit tests for my deep copy in v01/Tests/test-deep-compare