### PR TITLE
Add function resetDisplay to redraw grid when Raphael paper is destroyed and recreated

### DIFF
--- a/pemFioi/blocklyRobot_lib-1.0.0.js
+++ b/pemFioi/blocklyRobot_lib-1.0.0.js
@@ -3302,7 +3302,7 @@ var getContext = function(display, infos, curLevel) {
       }
    };
 
-   context.resetDisplay = function() {
+   context.redrawDisplay = function() {
       if(context.display) {
          this.raphaelFactory.destroyAll();
          if(paper !== undefined)
@@ -3315,7 +3315,7 @@ var getContext = function(display, infos, curLevel) {
       }
    }
 
-   context.getCurrentState = function() {
+   context.getInnerState = function() {
       return {
          items: context.items,
          multicell_items: context.multicell_items,
@@ -3327,7 +3327,7 @@ var getContext = function(display, infos, curLevel) {
       };
    };
 
-   context.reloadState = function(data) {
+   context.reloadInnerState = function(data) {
       context.items = data.items;
       context.multicell_items = data.multicell_items;
       context.last_connect = data.last_connect;

--- a/pemFioi/blocklyRobot_lib-1.0.0.js
+++ b/pemFioi/blocklyRobot_lib-1.0.0.js
@@ -3315,6 +3315,28 @@ var getContext = function(display, infos, curLevel) {
       }
    }
 
+   context.getCurrentState = function() {
+      return {
+         items: context.items,
+         multicell_items: context.multicell_items,
+         last_connect: context.last_connext,
+         wires: context.wires,
+         nbMoves: context.nbMoves,
+         time: context.time,
+         bag: context.bag,
+      };
+   };
+
+   context.reloadState = function(data) {
+      context.items = data.items;
+      context.multicell_items = data.multicell_items;
+      context.last_connect = data.last_connect;
+      context.wires = data.wires;
+      context.nbMoves = data.nbMoves;
+      context.time = data.time;
+      context.bag = data.bag;
+   };
+
    context.unload = function() {
       if(context.display && paper != null) {
          paper.remove();

--- a/pemFioi/blocklyRobot_lib-1.0.0.js
+++ b/pemFioi/blocklyRobot_lib-1.0.0.js
@@ -3301,7 +3301,20 @@ var getContext = function(display, infos, curLevel) {
          resetItems();
       }
    };
-   
+
+   context.resetDisplay = function() {
+      if(context.display) {
+         this.raphaelFactory.destroyAll();
+         if(paper !== undefined)
+            paper.remove();
+         paper = this.raphaelFactory.create("paperMain", "grid", infos.cellSide * context.nbCols * scale, infos.cellSide * context.nbRows * scale);
+         resetBoard();
+         redisplayAllItems();
+         context.updateScale();
+         $("#nbMoves").html(context.nbMoves);
+      }
+   }
+
    context.unload = function() {
       if(context.display && paper != null) {
          paper.remove();


### PR DESCRIPTION
@mblockelet Surprisingly, there wasn't any `resetDisplay` function in this version of the robot library. I've created one.
The purpose of this function is to destroy any previous display and recreate it without changing any internal state of the robot.
Could you confirm it's ok to do this? Or do you think I need to create a new version for this?