### PR TITLE
Avoid double validation

### DIFF
--- a/bundles/bebras-interface.js
+++ b/bundles/bebras-interface.js
@@ -3122,6 +3122,7 @@ var miniPlatformValidate = function(task) { return function(mode, success, error
          if (success) {
             success();
          }
+         return;
       } else {
          alreadyStayed = true;
       }

--- a/bundles/bebras-interface.js
+++ b/bundles/bebras-interface.js
@@ -3112,36 +3112,26 @@ function miniPlatformPreviewGrade(answer) {
 var alreadyStayed = false;
 
 var miniPlatformValidate = function(task) { return function(mode, success, error) {
-   //$.post('updateTestToken.php', {action: 'showSolution'}, function(){}, 'json');
-   if (mode == 'nextImmediate' || mode == 'log') {
+   if (!success) { success = function () { }; }
+   if (mode == 'nextImmediate' || mode == 'top' || mode == 'log') {
       return;
-   }
-   if (mode == 'stay') {
-      if (alreadyStayed) {
-         platform.trigger('validate', [mode]);
-         if (success) {
-            success();
-         }
-         return;
-      } else {
-         alreadyStayed = true;
-      }
    }
    if (mode == 'cancel') {
       alreadyStayed = false;
    }
-   if(platform.registered_objects && platform.registered_objects.length > 0) {
-       platform.trigger('validate', [mode]);
-   } else {
-        // Try to validate
-        task.getAnswer(function(answer) {
-            task.gradeAnswer(answer, task_token.getAnswerToken(answer), function(score, message) {
-                if(success) { success(); }
-                })
-            });
-   }
-   if (success) {
+   if (alreadyStayed || (platform.registered_objects && platform.registered_objects.length > 0)) {
+      platform.trigger('validate', [mode]);
       success();
+   } else {
+      // Try to validate
+      task.getAnswer(function (answer) {
+         task.gradeAnswer(answer, task_token.getAnswerToken(answer), function (score, message) {
+            success();
+         })
+      });
+   }
+   if (mode == 'stay') {
+      alreadyStayed = true;
    }
 }};
 

--- a/integrationAPI.01/official/miniPlatform.js
+++ b/integrationAPI.01/official/miniPlatform.js
@@ -287,36 +287,27 @@ function miniPlatformPreviewGrade(answer) {
 var alreadyStayed = false;
 
 var miniPlatformValidate = function(task) { return function(mode, success, error) {
-   //$.post('updateTestToken.php', {action: 'showSolution'}, function(){}, 'json');
-   if (mode == 'nextImmediate' || mode == 'top' || mode == 'log') {
-      return;
-   }
-   if (mode == 'stay') {
-      if (alreadyStayed) {
-         platform.trigger('validate', [mode]);
-         if (success) {
-            success();
-         }
-      } else {
-         alreadyStayed = true;
-      }
-   }
-   if (mode == 'cancel') {
-      alreadyStayed = false;
-   }
-   if(platform.registered_objects && platform.registered_objects.length > 0) {
-       platform.trigger('validate', [mode]);
-   } else {
-        // Try to validate
-        task.getAnswer(function(answer) {
-            task.gradeAnswer(answer, task_token.getAnswerToken(answer), function(score, message) {
-                if(success) { success(); }
-                })
-            });
-   }
-   if (success) {
-      success();
-   }
+  if (!success) { success = function () { }; }
+  if (mode == 'nextImmediate' || mode == 'top' || mode == 'log') {
+    return;
+  }
+  if (mode == 'cancel') {
+    alreadyStayed = false;
+  }
+  if (alreadyStayed || (platform.registered_objects && platform.registered_objects.length > 0)) {
+    platform.trigger('validate', [mode]);
+    success();
+  } else {
+    // Try to validate
+    task.getAnswer(function (answer) {
+      task.gradeAnswer(answer, task_token.getAnswerToken(answer), function (score, message) {
+        success();
+      })
+    });
+  }
+  if (mode == 'stay') {
+    alreadyStayed = true;
+  }
 }};
 
 function getUrlParameter(sParam)

--- a/integrationAPI.01/official/miniPlatform_M.js
+++ b/integrationAPI.01/official/miniPlatform_M.js
@@ -230,27 +230,27 @@ function miniPlatformPreviewGrade(answer) {
 var alreadyStayed = false;
 
 var miniPlatformValidate = function(mode, success, error) {
-   //$.post('updateTestToken.php', {action: 'showSolution'}, function(){}, 'json');
-   if (mode == 'nextImmediate' || mode == 'top' || mode == 'log') {
-      return;
-   }
-   if (mode == 'stay') {
-      if (alreadyStayed) {
-         platform.trigger('validate', [mode]);
-         if (success) {
-            success();
-         }
-      } else {
-         alreadyStayed = true;
-      }
-   }
-   if (mode == 'cancel') {
-      alreadyStayed = false;
-   }
-   platform.trigger('validate', [mode]);
-   if (success) {
-      success();
-   }
+  if (!success) { success = function () { }; }
+  if (mode == 'nextImmediate' || mode == 'top' || mode == 'log') {
+    return;
+  }
+  if (mode == 'cancel') {
+    alreadyStayed = false;
+  }
+  if (alreadyStayed || (platform.registered_objects && platform.registered_objects.length > 0)) {
+    platform.trigger('validate', [mode]);
+    success();
+  } else {
+    // Try to validate
+    task.getAnswer(function (answer) {
+      task.gradeAnswer(answer, task_token.getAnswerToken(answer), function (score, message) {
+        success();
+      })
+    });
+  }
+  if (mode == 'stay') {
+    alreadyStayed = true;
+  }
 };
 
 function getUrlParameter(sParam)


### PR DESCRIPTION
Currently when we do `platform.validate('stay')` on the miniplatform, `platform.trigger('validate', [mode]);` and `success` are called twice. But the code looks weird (what is the purpose of `alreadyStayed`?) so I would prefer you to review this @mblockelet :sweat_smile: 