### PR TITLE
Fix hint token parsing in miniPlatform.js

### DIFF
--- a/integrationAPI.01/official/miniPlatform.js
+++ b/integrationAPI.01/official/miniPlatform.js
@@ -196,7 +196,7 @@ function getLanguageString(key) {
 
         this.addHintRequest = function(hint_params, callback) {
             try {
-                hint_params = jwt.decode(hint_params).askedHint;
+                hint_params = jwt.decode(hint_params).claim.askedHint;
             } catch(e) {}
             var hintsReq = JSON.parse(this.data.sHintsRequested);
             var exists = hintsReq.find(function(h) {

--- a/integrationAPI.01/official/miniPlatform.js
+++ b/integrationAPI.01/official/miniPlatform.js
@@ -165,11 +165,7 @@ function getLanguageString(key) {
             decode: function(token) {
                 var parts = token.split('.');
 
-                return {
-                    header: JSON.parse(window.jwt.decode64(parts[0])),
-                    claim: JSON.parse(window.jwt.decode64(parts[1])),
-                    signature: (parts[2] || '')
-                };
+                return JSON.parse(window.jwt.decode64(parts[1]));
             },
             encode64: function (value) {
                 var encoded = btoa(unescape(encodeURIComponent(value)));
@@ -196,7 +192,7 @@ function getLanguageString(key) {
 
         this.addHintRequest = function(hint_params, callback) {
             try {
-                hint_params = jwt.decode(hint_params).claim.askedHint;
+                hint_params = jwt.decode(hint_params).askedHint;
             } catch(e) {}
             var hintsReq = JSON.parse(this.data.sHintsRequested);
             var exists = hintsReq.find(function(h) {


### PR DESCRIPTION
The dummy `window.jwt.decode` introduced in https://github.com/France-ioi/bebras-modules/commit/956e50db8b6deb1c92def84e42b05615f8cbc3c4 returns `{header: ..., claim: <content>, ...}` instead of returning the content directly (like `jwt` from the `jsonwebtoken` package does for instance).

This fix was necessary to migrate an Alkindi task from react-task-lib 3.0.0 to the latest version ([jwt.sign](https://github.com/France-ioi/react-task-lib/blob/aa5022789ac393ace7d8ca2ee8430a9d534590be/src/local_server_api.ts#L131 ) is trying to call crypto.createSign, so I'm trying to use the dummy window.jwt.sign instead).